### PR TITLE
Add insert, flush, and query methods to collection

### DIFF
--- a/examples/collection.rs
+++ b/examples/collection.rs
@@ -1,0 +1,56 @@
+use milvus::{client::Client, error::Error, schema::AsFieldDataValue};
+
+// #[derive(Debug, Clone, milvus::Entity)]
+// struct ImageEntity {
+//     #[milvus(primary, auto_id = false)]
+//     id: i64,
+//     #[milvus(dim = 1024)]
+//     hash: BitVec,
+//     listing_id: i32,
+//     provider: i8,
+// }
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    const URL: &str = "http://localhost:19530";
+    const NAME: &str = "images";
+
+    let client = Client::new(URL).await?;
+    let images = client.get_collection(NAME).await?.unwrap();
+
+    // let mut batch = InsertBatch::new();
+    // batch.push(ImageEntity {
+    //     id: 12,
+    //     hash: vec![1; 128],
+    //     listing_id: 17,
+    //     provider: 0,
+    // });
+
+    let mut fields = images.create_insert_frame().await?;
+    fields
+        .add([
+            ("id", &12i64 as &dyn AsFieldDataValue),
+            ("hash", &vec![1; 128]),
+            ("listing_id", &17i32),
+            ("provider", &0i8),
+        ])
+        .unwrap();
+
+    images.insert(fields, Option::<String>::None).await?;
+
+    let x = client.flush_collections(["images"]).await?;
+
+    println!("{:?}", x);
+
+    let fields = images
+        .query(
+            "id < 100",
+            ["id", "hash", "listing_id", "provider"],
+            [""; 0],
+        )
+        .await?;
+
+    println!("{:?}", fields);
+
+    Ok(())
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -17,13 +17,16 @@
 use crate::error;
 use crate::error::Result;
 use crate::proto::common::KeyValuePair;
-use crate::proto::schema;
-use crate::proto::schema::DataType;
+use crate::proto::schema::VectorField;
+use crate::proto::schema::{
+    self, field_data::Field, scalar_field::Data as ScalarData, DataType, ScalarField,
+};
 use prost::alloc::vec::Vec;
+use std::collections::HashMap;
 use std::error::Error as _;
 use thiserror::Error as ThisError;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FieldSchema {
     name: String,
     description: String,
@@ -44,6 +47,27 @@ impl Default for FieldSchema {
             auto_id: false,
             dim: 0,
             max_length: 0,
+        }
+    }
+}
+
+impl<'a> From<&'a schema::FieldSchema> for FieldSchema {
+    fn from(fld: &'a schema::FieldSchema) -> Self {
+        let dim: i32 = fld
+            .type_params
+            .iter()
+            .find(|k| &k.key == "dim")
+            .and_then(|x| x.value.parse().ok())
+            .unwrap_or(1);
+
+        FieldSchema {
+            name: fld.name.clone(),
+            description: fld.description.clone(),
+            dtype: DataType::from_i32(fld.data_type).unwrap(),
+            is_primary: fld.is_primary_key,
+            auto_id: fld.auto_id,
+            max_length: 0,
+            dim,
         }
     }
 }
@@ -154,7 +178,7 @@ impl FieldSchema {
             name: name.into(),
             description: description.into(),
             dtype: DataType::String,
-            max_length: max_length,
+            max_length,
             ..Default::default()
         }
     }
@@ -168,7 +192,7 @@ impl FieldSchema {
             name: name.into(),
             description: description.into(),
             dtype: DataType::BinaryVector,
-            dim: dim,
+            dim,
             ..Default::default()
         }
     }
@@ -182,7 +206,7 @@ impl FieldSchema {
             name: name.into(),
             description: description.into(),
             dtype: DataType::FloatVector,
-            dim: dim,
+            dim,
             ..Default::default()
         }
     }
@@ -211,6 +235,7 @@ impl FieldSchema {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct CollectionSchema {
     inner: Vec<FieldSchema>,
     auto_id: bool,
@@ -234,7 +259,16 @@ impl CollectionSchema {
     }
 }
 
-#[derive(Clone)]
+impl<'a> From<&'a schema::CollectionSchema> for CollectionSchema {
+    fn from(v: &'a schema::CollectionSchema) -> Self {
+        CollectionSchema {
+            inner: v.fields.iter().map(Into::into).collect(),
+            auto_id: v.auto_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct CollectionSchemaBuilder {
     inner: Vec<FieldSchema>,
 }
@@ -315,6 +349,410 @@ impl CollectionSchemaBuilder {
     }
 }
 
+pub trait AsFieldDataValue {
+    fn as_field_data_value(&self) -> FieldDataValue<'_>;
+}
+
+impl AsFieldDataValue for i64 {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::Int64(*self)
+    }
+}
+
+impl AsFieldDataValue for i32 {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::Int32(*self)
+    }
+}
+
+impl AsFieldDataValue for i16 {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::Int16(*self)
+    }
+}
+
+impl AsFieldDataValue for i8 {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::Int8(*self)
+    }
+}
+
+impl AsFieldDataValue for [u8] {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::BinaryVector(self)
+    }
+}
+
+impl AsFieldDataValue for Vec<u8> {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::BinaryVector(self)
+    }
+}
+
+impl AsFieldDataValue for [f32] {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::FloatVector(self)
+    }
+}
+
+impl AsFieldDataValue for Vec<f32> {
+    fn as_field_data_value(&self) -> FieldDataValue<'_> {
+        FieldDataValue::FloatVector(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum FieldDataValue<'a> {
+    None,
+    Bool(bool),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Float(f32),
+    Double(f64),
+    String(&'a str),
+    BinaryVector(&'a [u8]),
+    FloatVector(&'a [f32]),
+}
+
+impl<'a> FieldDataValue<'a> {
+    pub fn get_dim(&self) -> usize {
+        match self {
+            FieldDataValue::None => 0,
+            FieldDataValue::Bool(_)
+            | FieldDataValue::Int8(_)
+            | FieldDataValue::Int16(_)
+            | FieldDataValue::Int32(_)
+            | FieldDataValue::Int64(_)
+            | FieldDataValue::Float(_)
+            | FieldDataValue::Double(_)
+            | FieldDataValue::String(_) => 1,
+            FieldDataValue::BinaryVector(s) => s.len() * 8,
+            FieldDataValue::FloatVector(s) => s.len(),
+        }
+    }
+
+    #[inline]
+    pub fn data_type(&self) -> DataType {
+        match self {
+            FieldDataValue::None => DataType::None,
+            FieldDataValue::Bool(_) => DataType::Bool,
+            FieldDataValue::Int8(_) => DataType::Int8,
+            FieldDataValue::Int16(_) => DataType::Int16,
+            FieldDataValue::Int32(_) => DataType::Int32,
+            FieldDataValue::Int64(_) => DataType::Int64,
+            FieldDataValue::Float(_) => DataType::Float,
+            FieldDataValue::Double(_) => DataType::Double,
+            FieldDataValue::String(_) => DataType::String,
+            // FieldDataValue::VarChar(_) => DataType::VarChar,
+            FieldDataValue::BinaryVector(_) => DataType::BinaryVector,
+            FieldDataValue::FloatVector(_) => DataType::FloatVector,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum FieldDataKind {
+    None,
+    Bool(Vec<bool>),
+    Int8(Vec<i32>),
+    Int16(Vec<i32>),
+    Int32(Vec<i32>),
+    Int64(Vec<i64>),
+    Float(Vec<f32>),
+    Double(Vec<f64>),
+    String(Vec<String>),
+    VarChar(Vec<String>),
+
+    BinaryVector(i64, Vec<u8>),
+    FloatVector(i64, Vec<f32>),
+}
+
+impl FieldDataKind {
+    #[inline]
+    pub fn data_type(&self) -> DataType {
+        match self {
+            FieldDataKind::None => DataType::None,
+            FieldDataKind::Bool(_) => DataType::Bool,
+            FieldDataKind::Int8(_) => DataType::Int8,
+            FieldDataKind::Int16(_) => DataType::Int16,
+            FieldDataKind::Int32(_) => DataType::Int32,
+            FieldDataKind::Int64(_) => DataType::Int64,
+            FieldDataKind::Float(_) => DataType::Float,
+            FieldDataKind::Double(_) => DataType::Double,
+            FieldDataKind::String(_) => DataType::String,
+            FieldDataKind::VarChar(_) => DataType::VarChar,
+            FieldDataKind::BinaryVector(..) => DataType::BinaryVector,
+            FieldDataKind::FloatVector(..) => DataType::FloatVector,
+        }
+    }
+
+    fn push(&mut self, v: FieldDataValue) -> std::result::Result<(), Error> {
+        match (v, self) {
+            (FieldDataValue::Bool(v), FieldDataKind::Bool(vec)) => vec.push(v),
+            (FieldDataValue::Int8(v), FieldDataKind::Int8(vec)) => vec.push(v as _),
+            (FieldDataValue::Int16(v), FieldDataKind::Int16(vec)) => vec.push(v as _),
+            (FieldDataValue::Int32(v), FieldDataKind::Int32(vec)) => vec.push(v),
+            (FieldDataValue::Int64(v), FieldDataKind::Int64(vec)) => vec.push(v),
+            (FieldDataValue::Float(v), FieldDataKind::Float(vec)) => vec.push(v),
+            (FieldDataValue::Double(v), FieldDataKind::Double(vec)) => vec.push(v),
+            (FieldDataValue::String(v), FieldDataKind::String(vec)) => vec.push(v.to_string()),
+            (FieldDataValue::BinaryVector(v), FieldDataKind::BinaryVector(_, vec)) => {
+                vec.extend_from_slice(v)
+            }
+            (FieldDataValue::FloatVector(v), FieldDataKind::FloatVector(_, vec)) => {
+                vec.extend_from_slice(v)
+            }
+
+            (a, b) => return Err(Error::FieldWrongType(a.data_type(), b.data_type())),
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn dim(&self) -> i64 {
+        match self {
+            FieldDataKind::None => 0,
+            FieldDataKind::Bool(_)
+            | FieldDataKind::Int8(_)
+            | FieldDataKind::Int16(_)
+            | FieldDataKind::Int32(_)
+            | FieldDataKind::Int64(_)
+            | FieldDataKind::Float(_)
+            | FieldDataKind::Double(_)
+            | FieldDataKind::String(_)
+            | FieldDataKind::VarChar(_) => 1,
+            FieldDataKind::BinaryVector(d, _) => *d,
+            FieldDataKind::FloatVector(d, _) => *d,
+        }
+    }
+
+    fn convert(self) -> Field {
+        match self {
+            FieldDataKind::None => Field::Scalars(ScalarField { data: None }),
+            FieldDataKind::Bool(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::BoolData(schema::BoolArray { data: v })),
+            }),
+            FieldDataKind::Int8(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::IntData(schema::IntArray { data: v })),
+            }),
+            FieldDataKind::Int16(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::IntData(schema::IntArray { data: v })),
+            }),
+            FieldDataKind::Int32(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::IntData(schema::IntArray { data: v })),
+            }),
+            FieldDataKind::Int64(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::LongData(schema::LongArray { data: v })),
+            }),
+            FieldDataKind::Float(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::FloatData(schema::FloatArray { data: v })),
+            }),
+            FieldDataKind::Double(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::DoubleData(schema::DoubleArray { data: v })),
+            }),
+            FieldDataKind::String(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::StringData(schema::StringArray { data: v })),
+            }),
+            FieldDataKind::VarChar(v) => Field::Scalars(ScalarField {
+                data: Some(ScalarData::StringData(schema::StringArray { data: v })),
+            }),
+            FieldDataKind::BinaryVector(dim, v) => Field::Vectors(VectorField {
+                data: Some(schema::vector_field::Data::BinaryVector(v)),
+                dim,
+            }),
+            FieldDataKind::FloatVector(dim, v) => Field::Vectors(VectorField {
+                data: Some(schema::vector_field::Data::FloatVector(
+                    schema::FloatArray { data: v },
+                )),
+                dim,
+            }),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        match self {
+            FieldDataKind::None => (),
+            FieldDataKind::Bool(v) => v.clear(),
+            FieldDataKind::Int8(v) => v.clear(),
+            FieldDataKind::Int16(v) => v.clear(),
+            FieldDataKind::Int32(v) => v.clear(),
+            FieldDataKind::Int64(v) => v.clear(),
+            FieldDataKind::Float(v) => v.clear(),
+            FieldDataKind::Double(v) => v.clear(),
+            FieldDataKind::String(v) => v.clear(),
+            FieldDataKind::VarChar(v) => v.clear(),
+            FieldDataKind::BinaryVector(_, v) => v.clear(),
+            FieldDataKind::FloatVector(_, v) => v.clear(),
+        }
+    }
+}
+
+impl From<Field> for FieldDataKind {
+    fn from(f: Field) -> Self {
+        match f {
+            Field::Scalars(s) => match s.data {
+                Some(x) => match x {
+                    ScalarData::BoolData(v) => Self::Bool(v.data),
+                    ScalarData::IntData(v) => Self::Int32(v.data),
+                    ScalarData::LongData(v) => Self::Int64(v.data),
+                    ScalarData::FloatData(v) => Self::Float(v.data),
+                    ScalarData::DoubleData(v) => Self::Double(v.data),
+                    ScalarData::StringData(v) => Self::String(v.data),
+                    ScalarData::BytesData(v) => unimplemented!(), // Self::Bytes(v.data),
+                },
+                None => Self::None,
+            },
+
+            Field::Vectors(arr) => match arr.data {
+                Some(x) => match x {
+                    schema::vector_field::Data::FloatVector(v) => {
+                        Self::FloatVector(arr.dim, v.data)
+                    }
+                    schema::vector_field::Data::BinaryVector(v) => Self::BinaryVector(arr.dim, v),
+                },
+                None => Self::None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldData {
+    name: String,
+    dim: usize,
+    field: FieldDataKind,
+}
+
+impl FieldData {
+    fn new(name: String, dim: usize, field: FieldDataKind) -> Self {
+        Self { name, dim, field }
+    }
+
+    pub fn convert(self) -> schema::FieldData {
+        schema::FieldData {
+            field_name: self.name,
+            field_id: 0,
+            r#type: self.field.data_type() as _,
+            field: Some(self.field.convert()),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.field.clear();
+    }
+}
+
+impl From<schema::FieldData> for FieldData {
+    fn from(fd: schema::FieldData) -> Self {
+        let field: FieldDataKind = fd.field.map(Into::into).unwrap_or(FieldDataKind::None);
+
+        FieldData {
+            name: fd.field_name,
+            dim: field.dim() as _,
+            field,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CollectionFieldsData {
+    num_rows: usize,
+    fields: HashMap<String, FieldData>,
+}
+
+impl CollectionFieldsData {
+    pub fn add<'a, I: IntoIterator<Item = (&'a str, &'a dyn AsFieldDataValue)>>(
+        &mut self,
+        row: I,
+    ) -> std::result::Result<(), Error> {
+        for (k, v) in row {
+            let v: FieldDataValue = v.as_field_data_value();
+            let x = self
+                .fields
+                .get_mut(k)
+                .ok_or_else(|| Error::FieldDoesNotExists(k.to_string()))?;
+
+            let actual_dim = v.get_dim();
+
+            if actual_dim != x.dim {
+                return Err(Error::DimensionMismatch(
+                    k.to_string(),
+                    actual_dim as _,
+                    x.dim as _,
+                ));
+            }
+
+            x.field.push(v)?;
+        }
+
+        self.num_rows += 1;
+
+        Ok(())
+    }
+
+    pub fn new(schema: &CollectionSchema) -> Self {
+        let mut fields = HashMap::new();
+
+        for fld in schema.inner.iter() {
+            let (dim, knd) = match fld.dtype {
+                DataType::None => (0, FieldDataKind::None),
+                DataType::Bool => (1, FieldDataKind::Bool(Vec::new())),
+                DataType::Int8 => (1, FieldDataKind::Int8(Vec::new())),
+                DataType::Int16 => (1, FieldDataKind::Int16(Vec::new())),
+                DataType::Int32 => (1, FieldDataKind::Int32(Vec::new())),
+                DataType::Int64 => (1, FieldDataKind::Int64(Vec::new())),
+                DataType::Float => (1, FieldDataKind::Float(Vec::new())),
+                DataType::Double => (1, FieldDataKind::Double(Vec::new())),
+                DataType::String => (1, FieldDataKind::String(Vec::new())),
+                DataType::VarChar => (1, FieldDataKind::VarChar(Vec::new())),
+                DataType::BinaryVector => (
+                    fld.dim,
+                    FieldDataKind::BinaryVector(fld.dim as _, Vec::new()),
+                ),
+                DataType::FloatVector => (
+                    fld.dim,
+                    FieldDataKind::FloatVector(fld.dim as _, Vec::new()),
+                ),
+            };
+
+            fields.insert(
+                fld.name.clone(),
+                FieldData::new(fld.name.clone(), dim as _, knd),
+            );
+        }
+
+        Self {
+            fields,
+            num_rows: 0,
+        }
+    }
+
+    #[inline]
+    pub fn convert(self) -> Vec<schema::FieldData> {
+        self.fields.into_values().map(|x| x.convert()).collect()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.num_rows
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.num_rows == 0
+    }
+
+    pub fn clear(&mut self) {
+        self.num_rows = 0;
+        self.fields.values_mut().for_each(|x| x.clear())
+    }
+}
+
 #[derive(Debug, ThisError)]
 pub enum Error {
     #[error("try to set primary key {0:?}, but {1:?} is also key")]
@@ -328,6 +766,15 @@ pub enum Error {
 
     #[error("auto id must be int64, unsupported type {0:?}")]
     UnsupportedAutoId(DataType),
+
+    #[error("dimension mismatch for {0:?}, got {1:?}, expected {2:?}")]
+    DimensionMismatch(String, i32, i32),
+
+    #[error("wrong data type, got {0:?}, expected {1:?}")]
+    FieldWrongType(DataType, DataType),
+
+    #[error("field does not exists in schema: {0:?}")]
+    FieldDoesNotExists(String),
 
     #[error("can not find such key {0:?}")]
     NoSuchKey(String),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::common::{MsgBase, MsgType};
+use crate::{
+    error::Error,
+    proto::common::{ErrorCode, MsgBase, MsgType, Status},
+};
 
 pub fn new_msg(mtype: MsgType) -> MsgBase {
     MsgBase {
@@ -22,5 +25,17 @@ pub fn new_msg(mtype: MsgType) -> MsgBase {
         timestamp: 0,
         source_id: 0,
         msg_id: 0,
+    }
+}
+
+pub fn status_to_result(status: Option<Status>) -> Result<(), Error> {
+    let status = status.ok_or(Error::Unknown())?;
+
+    match ErrorCode::from_i32(status.error_code) {
+        Some(i) => match i {
+            ErrorCode::Success => Ok(()),
+            _ => Err(Error::from(status)),
+        },
+        None => Err(Error::Unknown()),
     }
 }


### PR DESCRIPTION
Here are the proposing changes
* `Client::flush_collections`
* `Collection::create_insert_frame` (temporal solution) I think it would be better to store schema inside collection itself
* `CollectionFieldsData` and `FieldData` 
* `Collection::insert`
* `Collection::query`