### PR TITLE
Add delete entities api and impl `Clone` for Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -35,6 +35,7 @@ use std::time::Duration;
 use tonic::codegen::StdError;
 use tonic::transport::Channel;
 
+#[derive(Clone)]
 pub struct Client {
     client: MilvusServiceClient<Channel>,
 }


### PR DESCRIPTION
We need to implement Clone to extract the client in the web framework.

Signed-off-by: kingzcheung <kingzcheung@gmail.com>
see https://github.com/milvus-io/milvus-sdk-rust/issues/38