### PR TITLE
Enable TLS & Authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "milvus"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = "0.8.2"
+tonic = {version = "0.8.2", features = ["tls", "tls-roots"]}
 prost = "0.11.0"
 tokio = { version = "1.17.0", features = ["full"] }
 thiserror = "1.0"
@@ -18,6 +18,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
+base64 = "0.21.0"
 
 [build-dependencies]
 tonic-build = "0.8.2"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::client::AuthInterceptor;
 use crate::data::FieldColumn;
 use crate::error::{Error as SuperError, Result};
 use crate::index::{IndexInfo, IndexParams, MetricType};
@@ -40,6 +41,7 @@ use crate::{config, proto::milvus::DeleteRequest};
 use prost::bytes::BytesMut;
 use prost::Message;
 use serde_json;
+use tonic::codegen::InterceptedService;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -61,7 +63,7 @@ type ConcurrentHashMap<K, V> = tokio::sync::RwLock<std::collections::HashMap<K, 
 
 #[derive(Debug)]
 pub struct Collection {
-    client: MilvusServiceClient<Channel>,
+    client: MilvusServiceClient<InterceptedService<Channel, AuthInterceptor>>,
     info: DescribeCollectionResponse,
     schema: CollectionSchema,
     partitions: Mutex<HashSet<String>>,
@@ -69,7 +71,7 @@ pub struct Collection {
 }
 
 impl Collection {
-    pub fn new(client: MilvusServiceClient<Channel>, info: DescribeCollectionResponse) -> Self {
+    pub fn new(client: MilvusServiceClient<InterceptedService<Channel, AuthInterceptor>>, info: DescribeCollectionResponse) -> Self {
         let schema = info.schema.clone().unwrap();
         Self {
             client,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -69,6 +69,8 @@ async fn create_has_drop_collection() -> Result<()> {
     const NAME: &str = "create_has_drop_collection";
 
     let client = Client::new(URL).await?;
+    // let client = ClientBuilder::new(URL).username("username").password("password").build().await?;
+
     let mut schema = CollectionSchemaBuilder::new(NAME, "hello world");
     let schema = schema
         .add_field(FieldSchema::new_int64("i64_field", ""))


### PR DESCRIPTION
This will allow the milvus mafia to do two things: 1) connect to connect to milvus databases through secure connections over the internet if required. 2) connect to milvus databases where the database has a password on it.

I don't think either of these are currently possible, but please do forgive my ignorance if they are.

Here is what I did: 
1) added a builder for creating an authenticated client. I put this at the top of src/client.rs we may want it somewhere else I'm easy.

```
#[derive(Clone)]
pub struct ClientBuilder<D> {
    dst: D,
    username: Option<String>,
    password: Option<String>,
}

impl<D> ClientBuilder<D>
where
    D: TryInto<tonic::transport::Endpoint> + Clone,
    D::Error: Into<StdError>,
    D::Error: std::fmt::Debug,
{
    pub fn new(dst: D) -> Self {
        Self {
            dst,
            username: None,
            password: None,
        }
    }

    pub fn username(mut self, username: &str) -> Self {
        self.username = Some(username.to_owned());
        self
    }

    pub fn password(mut self, password: &str) -> Self {
        self.password = Some(password.to_owned());
        self
    }

    pub async fn build(self) -> Result<Client> {
        Client::with_timeout(self.dst, RPC_TIMEOUT, self.username, self.password).await
    }
}
```

2) Created an authentication interceptor that injects the authorization header into RPC requests if the client has been authenticated otherwise just passes along the request without doing anything:

```
#[derive(Clone)]
pub struct AuthInterceptor {
    token: Option<String>,
}

impl Interceptor for AuthInterceptor {
    fn call(&mut self, mut req: Request<()>) -> std::result::Result<tonic::Request<()>, tonic::Status> {
        if let Some(ref token) = self.token {
            let header_value = format!("{}", token);
            req.metadata_mut()
                .insert("authorization", header_value.parse().unwrap());
        }

        Ok(req)
    }
}
```

3) Wrapped the connection target / channel with intercepted service type:

```
#[derive(Clone)]
pub struct Client {
    client: MilvusServiceClient<InterceptedService<Channel, AuthInterceptor>>,
}
```

4) This required updating the type of the client property on the Collection struct and accompanying constructor:

```
pub struct Collection {
    client: MilvusServiceClient<InterceptedService<Channel, AuthInterceptor>>,
    info: DescribeCollectionResponse,
    schema: CollectionSchema,
    partitions: Mutex<HashSet<String>>,
    session_timestamps: ConcurrentHashMap<String, Timestamp>,
}

impl Collection {
    pub fn new(client: MilvusServiceClient<InterceptedService<Channel, AuthInterceptor>>, info: DescribeCollectionResponse) -> Self {
        let schema = info.schema.clone().unwrap();
        Self {
            client,
            info: info,
            schema: schema.into(),
            partitions: Mutex::new(Default::default()),
            session_timestamps: ConcurrentHashMap::new(HashMap::new()),
        }
    }
}
```

5) I left Client::new() as a default that has None for the credentials options to not make a breaking change though may not matter that much at this early stage:

```
    pub async fn new<D>(dst: D) -> Result<Self>
    where
        D: TryInto<tonic::transport::Endpoint>,
        D::Error: Into<StdError>,
        D::Error: std::fmt::Debug,
    {
        Self::with_timeout(dst, RPC_TIMEOUT, None, None).await
    }
```

6) Changed with_timeout() to take an optional username and password along with dst and timeout:

```
    pub async fn with_timeout<D>(
        dst: D,
        timeout: Duration,
        username: Option<String>,
        password: Option<String>,
    ) -> Result<Self>
    where
        D: TryInto<tonic::transport::Endpoint>,
        D::Error: Into<StdError>,
        D::Error: std::fmt::Debug,
    {
        let mut dst: tonic::transport::Endpoint = dst.try_into().map_err(|err| {
            Error::InvalidParameter("url".to_owned(), format!("to parse {:?}", err))
        })?;

        dst = dst.timeout(timeout);

        let token = match (username, password) {
            (Some(username), Some(password)) => {
                let auth_token = format!("{}:{}", username, password);
                let auth_token = general_purpose::STANDARD.encode(auth_token);
                Some(auth_token)
            }
            _ => None,
        };

        let auth_interceptor = AuthInterceptor { token };

        let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;

        let client = MilvusServiceClient::with_interceptor(conn, auth_interceptor);

        Ok(Self { client })
    }
```

7) Added base64 - 0.21.0 to the cargo.toml to handle the base64 encoding of the credentials. Also added the TLS feature flags to "tonic" allowing secure connections over the internet:

```
[dependencies]
tonic = {version = "0.8.2", features = ["tls", "tls-roots"]}
prost = "0.11.0"
tokio = { version = "1.17.0", features = ["full"] }
thiserror = "1.0"
serde = { version = "1.0", features = ["derive"] }
serde_json = "1.0"
anyhow = "1.0"
strum = "0.24"
strum_macros = "0.24"
base64 = "0.21.0"
```

I did test this with my Zilliz cloud credentials and it did work, but I could not put them in this PR for obvious reasons. I have left out a commented out line that I used to test but with fake credentials instead of real ones.

Let me know what you guys think, there is doubtless a better way of doing / laying out everything, thoughts appreciated, If I did this pull request wrong lmk, many thanks

Deals with issue: #41 