### PR TITLE
Support create/drop/alter alias for collection

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::collection::Collection;
 use crate::config::RPC_TIMEOUT;
 use crate::error::{Error, Result};
 use crate::options::CreateCollectionOptions;
@@ -27,6 +26,7 @@ use crate::proto::milvus::{
 };
 use crate::schema::CollectionSchema;
 use crate::utils::status_to_result;
+use crate::{collection::Collection, proto::common::ErrorCode};
 use base64::engine::general_purpose;
 use base64::Engine;
 use prost::bytes::BytesMut;

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,4 +272,93 @@ impl Client {
             .map(|(k, v)| (k, v.data))
             .collect())
     }
+
+    // alias related:
+
+    /// Creates an alias for a collection.
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - The name of the collection.
+    /// * `alias` - The alias to be created.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` indicating success or failure.
+    pub async fn create_alias<S>(&self, collection_name: S, alias: S) -> Result<()>
+    where
+        S: Into<String>,
+    {
+        let collection_name = collection_name.into();
+        let alias = alias.into();
+        status_to_result(&Some(
+            self.client
+                .clone()
+                .create_alias(crate::proto::milvus::CreateAliasRequest {
+                    base: Some(MsgBase::new(MsgType::CreateAlias)),
+                    db_name: "".to_string(), // reserved
+                    collection_name,
+                    alias,
+                })
+                .await?
+                .into_inner(),
+        ))
+    }
+
+    /// Drops an alias.
+    ///
+    /// # Arguments
+    ///
+    /// * `alias` - The alias to be dropped.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` indicating success or failure.
+    pub async fn drop_alias<S>(&self, alias: S) -> Result<()>
+    where
+        S: Into<String>,
+    {
+        let alias = alias.into();
+        status_to_result(&Some(
+            self.client
+                .clone()
+                .drop_alias(crate::proto::milvus::DropAliasRequest {
+                    base: Some(MsgBase::new(MsgType::DropAlias)),
+                    db_name: "".to_string(), // reserved
+                    alias,
+                })
+                .await?
+                .into_inner(),
+        ))
+    }
+
+    /// Alter the alias of a collection.
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - The name of the collection.
+    /// * `alias` - The new alias for the collection.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` indicating success or failure.
+    pub async fn alter_alias<S>(&self, collection_name: S, alias: S) -> Result<()>
+    where
+        S: Into<String>,
+    {
+        let collection_name = collection_name.into();
+        let alias = alias.into();
+        status_to_result(&Some(
+            self.client
+                .clone()
+                .alter_alias(crate::proto::milvus::AlterAliasRequest {
+                    base: Some(MsgBase::new(MsgType::AlterAlias)),
+                    db_name: "".to_string(), // reserved
+                    collection_name,
+                    alias,
+                })
+                .await?
+                .into_inner(),
+        ))
+    }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -430,6 +430,10 @@ pub struct CollectionSchema {
 }
 
 impl CollectionSchema {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     #[inline]
     pub fn auto_id(&self) -> bool {
         self.fields.iter().any(|x| x.auto_id)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,13 +10,8 @@ pub const DEFAULT_VEC_FIELD: &str = "feature";
 pub const DEFAULT_INDEX_NAME: &str = "feature_index";
 pub const URL: &str = "http://localhost:19530";
 
-
 pub async fn create_test_collection() -> Result<Collection> {
-    let collection_name = rand::thread_rng()
-        .sample_iter(&rand::distributions::Alphanumeric)
-        .take(7)
-        .map(char::from)
-        .collect::<String>();
+    let collection_name = gen_random_name();
     let collection_name = format!("{}_{}", "test_collection", collection_name);
     let client = Client::new(URL).await?;
     let schema = CollectionSchemaBuilder::new(&collection_name, "")
@@ -38,6 +33,14 @@ pub async fn create_test_collection() -> Result<Collection> {
             )),
         )
         .await
+}
+
+pub fn gen_random_name() -> String {
+    rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(7)
+        .map(char::from)
+        .collect::<String>()
 }
 
 pub fn gen_random_f32_vector(n: i64) -> Vec<f32> {


### PR DESCRIPTION
This pull request adds support for creating, dropping, and altering aliases for collections in the Milvus client. It introduces three new methods: `create_alias`, `drop_alias`, and `alter_alias`. These methods allow users to manage aliases for collections, providing more flexibility in organizing and accessing data.

fix #78