### PR TITLE
feat: enable grpc keepalive with 10s interval and 5s timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ tonic-build = { version = "0.11.0", default-features = false, features = [
 rand = "0.8.5"
 
 [[test]]
+name = "client_keepalive"
+path = "tests/testsoutsideoftestsuite/client_keepalive.rs"
+
+[[test]]
 name = "client_with_timeout"
 path = "tests/testsoutsideoftestsuite/client_with_timeout.rs"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -172,7 +172,11 @@ impl Client {
             Error::InvalidParameter("url".to_owned(), format!("to parse {:?}", err))
         })?;
 
-        dst = dst.timeout(timeout);
+        dst = dst
+            .timeout(timeout)
+            .http2_keep_alive_interval(Duration::from_secs(10))
+            .keep_alive_timeout(Duration::from_secs(5))
+            .keep_alive_while_idle(true);
 
         let token = match (username, password) {
             (Some(username), Some(password)) => {

--- a/tests/testsoutsideoftestsuite/client_keepalive.rs
+++ b/tests/testsoutsideoftestsuite/client_keepalive.rs
@@ -1,0 +1,11 @@
+use milvus::client::*;
+
+const URL: &str = "http://localhost:19530";
+
+#[tokio::test]
+async fn test_client_keepalive() {
+    // Verify client connects successfully with keepalive settings
+    // (10s interval, 5s timeout, enabled while idle)
+    let client = Client::new(URL).await;
+    assert!(client.is_ok(), "Client should connect with keepalive enabled");
+}


### PR DESCRIPTION
## Summary
- Configure tonic `Endpoint` with HTTP/2 keepalive settings for faster dead connection detection
  - `http2_keep_alive_interval`: 10s (previously not set)
  - `keep_alive_timeout`: 5s (previously not set)
  - `keep_alive_while_idle`: true (previously not set)
- Add integration test verifying client connects successfully with keepalive enabled

## Test plan
- [ ] Verify `cargo check` passes (compilation)
- [ ] Verify `client_keepalive` integration test passes with a running Milvus instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)