### PR TITLE
fix(error): use status.code instead of error_code for Milvus > 2.3 compatibility

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@
 // For custom error handling
 // TODO
 
+use std::convert::TryFrom;
+
 use crate::collection::Error as CollectionError;
 use crate::proto::common::{ErrorCode, Status};
 use crate::schema::Error as SchemaError;
@@ -73,7 +75,13 @@ pub enum Error {
 
 impl From<Status> for Error {
     fn from(s: Status) -> Self {
-        Error::Server(ErrorCode::from_i32(s.error_code).unwrap(), s.reason)
+        let code = ErrorCode::try_from(s.code).unwrap_or(ErrorCode::UnexpectedError);
+        let reason = if code == ErrorCode::UnexpectedError && s.code != code as i32 {
+            format!("{} (code {})", s.reason, s.code)
+        } else {
+            s.reason
+        };
+        Error::Server(code, reason)
     }
 }
 


### PR DESCRIPTION
## Summary
- Milvus server versions > 2.3 use `status.code` instead of `status.error_code`.
- This PR updates `error.rs` and `utils.rs` to map `status.code` to `ErrorCode` properly.
- Falls back to `UnexpectedError` with the original code and reason if the code is unknown.