### PR TITLE
refactor: resolve clippy warnings and apply idiomatic rust patterns

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,7 +54,7 @@ impl Interceptor for AuthInterceptor {
         mut req: Request<()>,
     ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
         if let Some(ref token) = self.token {
-            let header_value = format!("{}", token);
+            let header_value = token.to_string();
             req.metadata_mut()
                 .insert("authorization", header_value.parse().unwrap());
         }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::TryFrom;
 
 use crate::{
     proto::schema::{
@@ -58,7 +59,7 @@ impl From<schema::FieldData> for FieldColumn {
             .unwrap_or((Some(1), None));
 
         let value: ValueVec = fd.field.map(Into::into).unwrap_or(ValueVec::None);
-        let dtype = DataType::from_i32(fd.r#type).unwrap_or(DataType::None);
+        let dtype = DataType::try_from(fd.r#type).unwrap_or(DataType::None);
 
         FieldColumn {
             name: fd.field_name,
@@ -133,6 +134,11 @@ impl FieldColumn {
     #[inline]
     pub fn len(&self) -> usize {
         self.value.len() / self.dim as usize
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn copy_with_metadata(&self) -> Self {

--- a/src/database.rs
+++ b/src/database.rs
@@ -57,7 +57,7 @@ use crate::{error::*, proto};
 ///     .force_deny_writing(false)
 ///     .force_deny_reading(false);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CreateDbOptions {
     /// Number of replicas for the database
     replica_number: Option<i32>,
@@ -75,19 +75,6 @@ pub struct CreateDbOptions {
 
 /// Type alias for database properties, currently equivalent to CreateDbOptions
 type DbProperties = CreateDbOptions;
-
-impl Default for CreateDbOptions {
-    fn default() -> Self {
-        Self {
-            replica_number: None,
-            resource_groups: None,
-            diskquota_mb: None,
-            max_collections: None,
-            force_deny_writing: None,
-            force_deny_reading: None,
-        }
-    }
-}
 
 impl CreateDbOptions {
     /// Creates a new `CreateDbOptions` instance with default values.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -171,7 +171,7 @@ impl From<IndexDescription> for IndexInfo {
             index_name: description.index_name.clone(),
             field_name: description.field_name.clone(),
             id: description.index_id,
-            params: params,
+            params,
             state: description.state(),
         }
     }

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -12,17 +12,9 @@ use crate::{
     value::ValueVec,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct InsertOptions {
     pub(crate) partition_name: String,
-}
-
-impl Default for InsertOptions {
-    fn default() -> Self {
-        Self {
-            partition_name: String::new(),
-        }
-    }
 }
 
 impl InsertOptions {
@@ -126,7 +118,7 @@ impl Client {
                 base: Some(MsgBase::new(MsgType::Delete)),
                 db_name: "".to_string(),
                 collection_name: collection_name.clone(),
-                expr: expr,
+                expr,
                 partition_name: options.partition_name.clone(),
                 hash_keys: Vec::new(),
                 consistency_level: crate::proto::common::ConsistencyLevel::Strong.into(),
@@ -154,22 +146,22 @@ impl Client {
                     (DataType::Int64, ValueVec::Long(values)) => {
                         for (i, v) in values.iter().enumerate() {
                             if i > 0 {
-                                expr.push_str(",");
+                                expr.push(',');
                             }
                             expr.push_str(format!("{}", v).as_str());
                         }
-                        expr.push_str("]");
+                        expr.push(']');
                         expr
                     }
 
                     (DataType::VarChar, ValueVec::String(values)) => {
                         for (i, v) in values.iter().enumerate() {
                             if i > 0 {
-                                expr.push_str(",");
+                                expr.push(',');
                             }
                             expr.push_str(v.as_str());
                         }
-                        expr.push_str("]");
+                        expr.push(']');
                         expr
                     }
 

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -13,17 +13,9 @@ use crate::{
     value::ValueVec,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct InsertOptions {
     pub(crate) partition_name: String,
-}
-
-impl Default for InsertOptions {
-    fn default() -> Self {
-        Self {
-            partition_name: String::new(),
-        }
-    }
 }
 
 impl InsertOptions {
@@ -129,7 +121,7 @@ impl Client {
                 base: Some(MsgBase::new(MsgType::Delete)),
                 db_name: "".to_string(),
                 collection_name: collection_name.clone(),
-                expr: expr,
+                expr,
                 partition_name: options.partition_name.clone(),
                 hash_keys: Vec::new(),
                 consistency_level: crate::proto::common::ConsistencyLevel::Strong.into(),
@@ -159,22 +151,22 @@ impl Client {
                     (DataType::Int64, ValueVec::Long(values)) => {
                         for (i, v) in values.iter().enumerate() {
                             if i > 0 {
-                                expr.push_str(",");
+                                expr.push(',');
                             }
                             expr.push_str(format!("{}", v).as_str());
                         }
-                        expr.push_str("]");
+                        expr.push(']');
                         expr
                     }
 
                     (DataType::VarChar, ValueVec::String(values)) => {
                         for (i, v) in values.iter().enumerate() {
                             if i > 0 {
-                                expr.push_str(",");
+                                expr.push(',');
                             }
                             expr.push_str(v.as_str());
                         }
-                        expr.push_str("]");
+                        expr.push(']');
                         expr
                     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -102,17 +102,9 @@ impl LoadOptions {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct GetLoadStateOptions {
     pub(crate) partition_names: Vec<String>,
-}
-
-impl Default for GetLoadStateOptions {
-    fn default() -> Self {
-        Self {
-            partition_names: vec![],
-        }
-    }
 }
 
 impl GetLoadStateOptions {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use crate::proto::{self, schema::DataType};
 
 pub(crate) type Timestamp = u64;
@@ -17,7 +19,7 @@ impl From<proto::schema::FieldSchema> for Field {
             id: value.field_id,
             name: value.name,
             description: value.description,
-            dtype: DataType::from_i32(value.data_type).unwrap_or(DataType::None),
+            dtype: DataType::try_from(value.data_type).unwrap_or(DataType::None),
             is_primary_key: value.is_primary_key,
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -223,21 +223,21 @@ impl ValueVec {
     }
 
     pub fn check_dtype(&self, dtype: DataType) -> bool {
-        match (self, dtype) {
+        matches!(
+            (self, dtype),
             (ValueVec::Binary(..), DataType::BinaryVector)
-            | (ValueVec::Float(..), DataType::FloatVector)
-            | (ValueVec::Float(..), DataType::Float)
-            | (ValueVec::Int(..), DataType::Int8)
-            | (ValueVec::Int(..), DataType::Int16)
-            | (ValueVec::Int(..), DataType::Int32)
-            | (ValueVec::Long(..), DataType::Int64)
-            | (ValueVec::Bool(..), DataType::Bool)
-            | (ValueVec::String(..), DataType::String)
-            | (ValueVec::String(..), DataType::VarChar)
-            | (ValueVec::None, _)
-            | (ValueVec::Double(..), DataType::Double) => true,
-            _ => false,
-        }
+                | (ValueVec::Float(..), DataType::FloatVector)
+                | (ValueVec::Float(..), DataType::Float)
+                | (ValueVec::Int(..), DataType::Int8)
+                | (ValueVec::Int(..), DataType::Int16)
+                | (ValueVec::Int(..), DataType::Int32)
+                | (ValueVec::Long(..), DataType::Int64)
+                | (ValueVec::Bool(..), DataType::Bool)
+                | (ValueVec::String(..), DataType::String)
+                | (ValueVec::String(..), DataType::VarChar)
+                | (ValueVec::None, _)
+                | (ValueVec::Double(..), DataType::Double)
+        )
     }
 
     #[inline]


### PR DESCRIPTION
## Summary
- Resolves various clippy warnings across the codebase.
- Replaces `push_str(",")` with `push(',')`.
- Uses `matches!()` macro where appropriate.
- Adds `is_empty()` method to `FieldColumn`.
- Removes redundant manual `Default` implementations in favor of `#[derive(Default)]`.
- Simplifies struct initializations (field init shorthand).