### PR TITLE
feat: add FMINDEX to IndexType

### DIFF
--- a/src/v1/index/mod.rs
+++ b/src/v1/index/mod.rs
@@ -68,6 +68,10 @@ pub enum IndexType {
     Ngram,
     #[strum(serialize = "STL_SORT")]
     StlSort,
+    // Appended at the tail: the enum has no explicit discriminants, so a new
+    // variant inserted mid-list would shift every one after it.
+    #[strum(serialize = "FMINDEX")]
+    FmIndex,
 }
 
 #[allow(non_camel_case_types)]
@@ -236,6 +240,7 @@ mod tests {
             (IndexType::GpuCagra, "GPU_CAGRA"),
             (IndexType::MinhashLsh, "MINHASH_LSH"),
             (IndexType::Ngram, "NGRAM"),
+            (IndexType::FmIndex, "FMINDEX"),
             (IndexType::StlSort, "STL_SORT"),
         ];
 


### PR DESCRIPTION
Closes #130.

`FMINDEX` is a new scalar index type on the Milvus server (scalar index engine
version 5, merged in milvus-io/milvus#51375): an exact byte-level substring index
for VARCHAR that answers anchored `LIKE` — prefix, infix and suffix — with no
candidate recheck.

Two ways the omission bites. `IndexType` is a closed strum enum with no
`Other(String)` variant, so a user cannot construct one. And on the read path,
`index_from_map` does `IndexType::from_str(&s).ok()`, which silently yields `None`
for an unknown name — so even an FMINDEX created through another client is invisible
here, with `describe_index` reporting no index type rather than an error.

Adds the variant and its entry in `index_type_round_trip_for_supported_variants`.

Build params are optional and travel through the usual params map:
`fm_sa_sample_rate` (4..256, server default 8) and `fm_block_bytes` (a power of two
in 8..128, server default 64). VARCHAR only in this release.

`cargo test --lib` passes (20/20). Note the crate needs
`git submodule update --init` for `milvus-proto` before `build.rs` can run protoc.
