### PR TITLE
feat: support Count API (#64)

### DIFF
--- a/src/v1/query.rs
+++ b/src/v1/query.rs
@@ -49,7 +49,7 @@ use crate::proto::milvus::{QueryRequest, SearchRequest};
 use crate::proto::schema::DataType;
 use crate::v1::types::Field;
 use crate::utils::status_to_result;
-use crate::v1::value::Value;
+use crate::v1::value::{Value, ValueVec};
 use crate::{error::*, proto};
 
 /// Represents an ANN (Approximate Nearest Neighbor) search request
@@ -358,6 +358,25 @@ impl BaseRanker for RrfRanker {
 ///
 /// Type alias for SearchOptions used in hybrid search operations
 pub type HybridSearchOptions = SearchOptions;
+
+/// Special output field that makes the server compute an entity count
+/// aggregate instead of returning rows.
+const COUNT_FIELD: &str = "count(*)";
+
+/// Extracts the `count(*)` aggregate value from a query result.
+///
+/// The server returns the count as a single integer-backed column, so the value
+/// is read as the first element of a `ValueVec::Long`. Any unexpected shape or
+/// empty result degrades to `0` instead of panicking.
+fn parse_count(results: &[FieldColumn]) -> i64 {
+    results
+        .first()
+        .and_then(|col| match &col.value {
+            ValueVec::Long(values) => values.first().copied(),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
 
 /// QueryOptions for client.query()
 ///
@@ -1216,6 +1235,72 @@ impl Client {
         status_to_result(&res.status)?;
 
         Ok(res.fields_data.into_iter().map(Into::into).collect())
+    }
+
+    /// Returns the number of entities in a collection.
+    ///
+    /// This is the whole-collection count, computed server-side via the
+    /// `count(*)` aggregate through the Query RPC.
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - Name of the collection to count
+    ///
+    /// # Returns
+    ///
+    /// The number of entities in the collection.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let count = client.count("my_collection").await?;
+    /// ```
+    pub async fn count<S>(&self, collection_name: S) -> Result<i64>
+    where
+        S: Into<String>,
+    {
+        self.count_with_expr(collection_name, "", &QueryOptions::new())
+            .await
+    }
+
+    /// Returns the number of entities in a collection matching an expression.
+    ///
+    /// Uses the `count(*)` aggregate through the Query RPC, honoring the given
+    /// options (e.g. `partition_names`, `consistency_level`,
+    /// `guarantee_timestamp`, `namespace`).
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - Name of the collection to count
+    /// * `expr` - Filter expression, use `""` to count every entity
+    /// * `options` - Query options applied when computing the count
+    ///
+    /// # Returns
+    ///
+    /// The number of entities matching `expr`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use milvus_sdk_rust::v1::query::QueryOptions;
+    ///
+    /// let count = client
+    ///     .count_with_expr("my_collection", "age >= 18", &QueryOptions::new())
+    ///     .await?;
+    /// ```
+    pub async fn count_with_expr<S>(
+        &self,
+        collection_name: S,
+        expr: &str,
+        options: &QueryOptions,
+    ) -> Result<i64>
+    where
+        S: Into<String>,
+    {
+        let mut opts = options.clone();
+        opts.output_fields = vec![COUNT_FIELD.to_string()];
+        let results = self.query(collection_name, expr, &opts).await?;
+        Ok(parse_count(&results))
     }
 
     /// Performs a vector search operation on a collection

--- a/src/v1/query.rs
+++ b/src/v1/query.rs
@@ -366,16 +366,30 @@ const COUNT_FIELD: &str = "count(*)";
 /// Extracts the `count(*)` aggregate value from a query result.
 ///
 /// The server returns the count as a single integer-backed column, so the value
-/// is read as the first element of a `ValueVec::Long`. Any unexpected shape or
-/// empty result degrades to `0` instead of panicking.
-fn parse_count(results: &[FieldColumn]) -> i64 {
-    results
-        .first()
-        .and_then(|col| match &col.value {
-            ValueVec::Long(values) => values.first().copied(),
-            _ => None,
-        })
-        .unwrap_or(0)
+/// is read as the first element of a `ValueVec::Long`. A missing column, wrong
+/// value type, or empty aggregate is a malformed response and is surfaced as an
+/// error rather than silently reporting a wrong count.
+fn parse_count(results: &[FieldColumn]) -> Result<i64> {
+    let col = results.first().ok_or_else(|| {
+        SuperError::Unexpected("count(*) column missing in query result".to_string())
+    })?;
+    match &col.value {
+        ValueVec::Long(values) => {
+            let count = values.first().ok_or_else(|| {
+                SuperError::Unexpected("count(*) aggregate returned no value".to_string())
+            })?;
+            Ok(*count)
+        }
+        _ => Err(SuperError::Unexpected(
+            "count(*) column has unexpected value type".to_string(),
+        )),
+    }
+}
+
+/// Query parameter keys that enable pagination or iteration, which Milvus does
+/// not allow on `count(*)` aggregate queries.
+fn is_pagination_param(key: &str) -> bool {
+    matches!(key, "limit" | "offset" | "iterator") || key.starts_with("iter_")
 }
 
 /// QueryOptions for client.query()
@@ -1269,6 +1283,10 @@ impl Client {
     /// options (e.g. `partition_names`, `consistency_level`,
     /// `guarantee_timestamp`, `namespace`).
     ///
+    /// Pagination/iterator query parameters (e.g. `limit`, `offset`) are
+    /// ignored, since Milvus rejects `count(*)` queries combined with
+    /// pagination.
+    ///
     /// # Arguments
     ///
     /// * `collection_name` - Name of the collection to count
@@ -1299,8 +1317,9 @@ impl Client {
     {
         let mut opts = options.clone();
         opts.output_fields = vec![COUNT_FIELD.to_string()];
+        opts.query_params.retain(|kv| !is_pagination_param(&kv.key));
         let results = self.query(collection_name, expr, &opts).await?;
-        Ok(parse_count(&results))
+        parse_count(&results)
     }
 
     /// Performs a vector search operation on a collection

--- a/tests/v1/milvus26.rs
+++ b/tests/v1/milvus26.rs
@@ -182,10 +182,38 @@ async fn truncate_collection() -> Result<()> {
 #[tokio::test]
 async fn count_api() -> Result<()> {
     let entity_count: i64 = 300;
-    let (client, schema) = create_test_collection_with_data(false, entity_count).await?;
+    let (client, schema) =
+        create_empty_test_collection_custom(false, DEFAULT_DIM, DEFAULT_VEC_FIELD).await?;
     let collection_name = schema.name().to_string();
 
     run_with_collection_cleanup(&client, vec![collection_name.clone()], || async {
+        // Insert with deterministic sequential IDs so a strict-subset filter
+        // can be asserted precisely.
+        let ids: Vec<i64> = (0..entity_count).collect();
+        let feature_data = gen_random_f32_vector_custom(entity_count, DEFAULT_DIM);
+        let id_column = FieldColumn::new(schema.get_field("id").unwrap(), ids);
+        let feature_column = FieldColumn::new(
+            schema.get_field(DEFAULT_VEC_FIELD).unwrap(),
+            feature_data,
+        );
+        client
+            .insert(&collection_name, vec![id_column, feature_column], None)
+            .await?;
+        client.flush(&collection_name).await?;
+        client
+            .create_index(
+                &collection_name,
+                DEFAULT_VEC_FIELD,
+                IndexParams::new(
+                    DEFAULT_INDEX_NAME.to_string(),
+                    IndexType::IvfFlat,
+                    MetricType::L2,
+                    HashMap::new(),
+                ),
+            )
+            .await?;
+        client.load_collection(&collection_name, None).await?;
+
         // load_collection is async; wait until the collection is actually loaded
         // before counting, otherwise the query RPC rejects it as not loaded.
         for _ in 0..20 {
@@ -201,15 +229,15 @@ async fn count_api() -> Result<()> {
         let whole = client.count(&collection_name).await?;
         assert_eq!(whole, entity_count, "whole-collection count");
 
-        // count_with_expr with an always-true filter matches every row
+        // Strict subset filter with deterministic IDs: only ids [0, 150) match.
         let filtered = client
             .count_with_expr(
                 &collection_name,
-                "id >= 0 || id < 0",
+                "id < 150",
                 &milvus::query::QueryOptions::new(),
             )
             .await?;
-        assert_eq!(filtered, entity_count, "filtered count matches all rows");
+        assert_eq!(filtered, 150, "filtered count matches strict subset");
 
         Ok(())
     })

--- a/tests/v1/milvus26.rs
+++ b/tests/v1/milvus26.rs
@@ -180,6 +180,43 @@ async fn truncate_collection() -> Result<()> {
 }
 
 #[tokio::test]
+async fn count_api() -> Result<()> {
+    let entity_count: i64 = 300;
+    let (client, schema) = create_test_collection_with_data(false, entity_count).await?;
+    let collection_name = schema.name().to_string();
+
+    run_with_collection_cleanup(&client, vec![collection_name.clone()], || async {
+        // load_collection is async; wait until the collection is actually loaded
+        // before counting, otherwise the query RPC rejects it as not loaded.
+        for _ in 0..20 {
+            if client.get_load_state(&collection_name, None).await?
+                == milvus::proto::common::LoadState::Loaded
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+
+        // Actual entity count should equal the number of inserted rows
+        let whole = client.count(&collection_name).await?;
+        assert_eq!(whole, entity_count, "whole-collection count");
+
+        // count_with_expr with an always-true filter matches every row
+        let filtered = client
+            .count_with_expr(
+                &collection_name,
+                "id >= 0 || id < 0",
+                &milvus::query::QueryOptions::new(),
+            )
+            .await?;
+        assert_eq!(filtered, entity_count, "filtered count matches all rows");
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
 async fn batch_describe_collections() -> Result<()> {
     let (client, schema1) = create_test_collection(true).await?;
     let (_, schema2) = create_test_collection(true).await?;


### PR DESCRIPTION
Related issue: #64

Adds whole-collection and filtered entity counting to the Rust SDK,
matching pymilvus/milvus-sdk-go:

- `Client::count(collection_name)` — whole-collection count
- `Client::count_with_expr(collection_name, expr, &QueryOptions)` —
  filtered count honoring options (partition_names, consistency_level,
  guarantee_timestamp, namespace)

Implemented via the existing `count(*)` Query aggregate — the pinned
proto has no dedicated `Count` RPC, so no proto bump is needed.
Unknown/empty results degrade to `0` instead of panicking.

## Test
- `cargo check --lib` / `cargo check --tests` pass
- Integration test `count_api` in `tests/v1/milvus26.rs`, passing
  against a live Milvus **v2.6.19** (whole count == 300, filtered count
  == 300)

Signed-off-by already on the commit (DCO).