### PR TITLE
feat: add client telemetry support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
+hostname = "0.4"
+sha2 = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
 base64 = "0.22.1"
@@ -56,6 +59,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 webpki-roots = "1.0"
 tokio-util = "0.7"
 tracing = { version = "0.1", optional = true }
+uuid = { version = "1.11", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = { version = "0.13", default-features = false, features = [
@@ -64,7 +68,6 @@ tonic-build = { version = "0.13", default-features = false, features = [
 protoc-bin-vendored = "=3.2.0"
 
 [dev-dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std"] }
 rand = "0.8.5"
 tokio-stream = { version = "0.1", features = ["net"] }
 

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -49,6 +49,7 @@ use crate::v2::error::{Error, Result};
 use crate::v2::types::{is_global_endpoint, ConnectConfig, RetryConfig};
 use parking_lot::RwLock;
 use std::future::Future;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tonic::codegen::InterceptedService;
@@ -208,6 +209,7 @@ enum RetrySemantics {
 struct V2Interceptor {
     token: Option<MetadataValue<tonic::metadata::Ascii>>,
     database: Arc<RwLock<String>>,
+    database_explicit: Arc<AtomicBool>,
 }
 
 impl Interceptor for V2Interceptor {
@@ -221,7 +223,12 @@ impl Interceptor for V2Interceptor {
                 .insert("authorization", token.clone());
         }
         let database = self.database.read();
-        if !database.is_empty() && database.as_str() != "default" {
+        if !database.is_empty()
+            && (database.as_str() != "default"
+                || self
+                    .database_explicit
+                    .load(std::sync::atomic::Ordering::Acquire))
+        {
             let value = database.parse().map_err(|_| {
                 tonic::Status::invalid_argument("database name is not valid metadata")
             })?;
@@ -282,6 +289,7 @@ impl Interceptor for V2Interceptor {
 pub struct ClientV2 {
     service: SharedServices,
     database: Arc<RwLock<String>>,
+    database_explicit: Arc<AtomicBool>,
     rpc_timeout: Arc<RwLock<Duration>>,
     retry: Arc<RwLock<RetryConfig>>,
     cache_endpoint: Arc<String>,
@@ -298,6 +306,7 @@ impl ClientV2 {
 
     async fn connect(param: ConnectConfig) -> Result<Self> {
         let database = Arc::new(RwLock::new(normalize_database(param.database.clone())?));
+        let database_explicit = Arc::new(AtomicBool::new(!param.database.is_empty()));
         let token = param
             .token
             .as_deref()
@@ -314,8 +323,14 @@ impl ClientV2 {
             let topology = global_cluster::fetch_topology(&param.uri, &param).await?;
             let primary_endpoint = topology.primary()?.endpoint().to_owned();
             let primary_uri = global_cluster::cluster_endpoint_uri(&primary_endpoint, &param)?;
-            let mut services =
-                global_cluster::build_services(&primary_uri, &param, &database, 0).await?;
+            let mut services = global_cluster::build_services(
+                &primary_uri,
+                &param,
+                &database,
+                &database_explicit,
+                0,
+            )
+            .await?;
             wait_for_server(&mut services.milvus, param.connect_timeout).await?;
             let service = Arc::new(RwLock::new(services));
             // The cache endpoint is the global URI itself, resolved with the same
@@ -327,6 +342,7 @@ impl ClientV2 {
                 param.uri.clone(),
                 param.clone(),
                 Arc::clone(&database),
+                Arc::clone(&database_explicit),
                 Arc::clone(&service),
                 topology,
             ));
@@ -338,6 +354,7 @@ impl ClientV2 {
             let interceptor = V2Interceptor {
                 token,
                 database: Arc::clone(&database),
+                database_explicit: Arc::clone(&database_explicit),
             };
             let mut services = service_bundle(channel, interceptor, 0);
             wait_for_server(&mut services.milvus, param.connect_timeout).await?;
@@ -353,6 +370,7 @@ impl ClientV2 {
             param.telemetry.clone(),
             Arc::clone(&service),
             Arc::clone(&database),
+            Arc::clone(&database_explicit),
             &param,
         );
         telemetry.start();
@@ -360,6 +378,7 @@ impl ClientV2 {
         Ok(Self {
             service,
             database,
+            database_explicit,
             rpc_timeout: Arc::new(RwLock::new(param.rpc_timeout)),
             retry: Arc::new(RwLock::new(param.retry)),
             cache_endpoint,
@@ -832,10 +851,12 @@ mod retry_tests {
 
     fn client(retry: RetryConfig) -> ClientV2 {
         let database = Arc::new(RwLock::new("default".to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(false));
         let channel = Endpoint::from_static("http://127.0.0.1:19530").connect_lazy();
         let interceptor = V2Interceptor {
             token: None,
             database: Arc::clone(&database),
+            database_explicit: Arc::clone(&database_explicit),
         };
         let service = Arc::new(RwLock::new(service_bundle(channel, interceptor, 0)));
         let config = ConnectConfig::new().telemetry(TelemetryConfig::new().enabled(false));
@@ -843,11 +864,13 @@ mod retry_tests {
             config.telemetry.clone(),
             Arc::clone(&service),
             Arc::clone(&database),
+            Arc::clone(&database_explicit),
             &config,
         );
         ClientV2 {
             service,
             database,
+            database_explicit,
             rpc_timeout: Arc::new(RwLock::new(Duration::from_secs(1))),
             retry: Arc::new(RwLock::new(retry)),
             cache_endpoint: Arc::new("http://127.0.0.1:19530".to_owned()),
@@ -900,6 +923,7 @@ mod retry_tests {
         let mut interceptor = V2Interceptor {
             token,
             database: Arc::new(RwLock::new(String::new())),
+            database_explicit: Arc::new(AtomicBool::new(false)),
         };
 
         let request = interceptor.call(Request::new(())).unwrap();
@@ -911,6 +935,32 @@ mod retry_tests {
                 .to_str()
                 .unwrap(),
             "cm9vdDpNaWx2dXM="
+        );
+    }
+
+    #[test]
+    fn interceptor_distinguishes_unset_and_explicit_default_database() {
+        let database = Arc::new(RwLock::new("default".to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(false));
+        let mut interceptor = V2Interceptor {
+            token: None,
+            database,
+            database_explicit: Arc::clone(&database_explicit),
+        };
+
+        let unset = interceptor.call(Request::new(())).unwrap();
+        assert!(unset.metadata().get("dbname").is_none());
+
+        database_explicit.store(true, std::sync::atomic::Ordering::Release);
+        let explicit = interceptor.call(Request::new(())).unwrap();
+        assert_eq!(
+            explicit
+                .metadata()
+                .get("dbname")
+                .expect("explicit default database")
+                .to_str()
+                .unwrap(),
+            "default"
         );
     }
 

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -42,6 +42,7 @@
 //! requests use non-idempotent semantics when replaying an ambiguous transport failure could
 //! duplicate a server-side operation.
 
+use crate::proto::milvus::client_telemetry_service_client::ClientTelemetryServiceClient;
 use crate::proto::milvus::milvus_service_client::MilvusServiceClient;
 use crate::proto::{common, milvus};
 use crate::v2::error::{Error, Result};
@@ -49,7 +50,7 @@ use crate::v2::types::{is_global_endpoint, ConnectConfig, RetryConfig};
 use parking_lot::RwLock;
 use std::future::Future;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tonic::codegen::InterceptedService;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
@@ -137,13 +138,42 @@ mod rbac;
 mod resource_group;
 mod session;
 mod snapshot;
+mod telemetry;
 mod utility;
 
 pub use iterator::{QueryIterator, SearchIterator, SearchIteratorV1, SearchIteratorV2};
 pub use session::MilvusClientV2Session;
+pub use telemetry::{
+    new_client_request_id, with_client_request_id, ClientTelemetry, ClientTelemetryCommand,
+    ClientTelemetryCommandReply, TelemetryErrorInfo, TelemetryMetrics, TelemetryOperationMetrics,
+    TelemetrySnapshot,
+};
 pub use utility::OptimizeTask;
 
 type Service = MilvusServiceClient<InterceptedService<Channel, V2Interceptor>>;
+type TelemetryService = ClientTelemetryServiceClient<InterceptedService<Channel, V2Interceptor>>;
+pub(super) type TransportGeneration = u64;
+
+#[derive(Clone)]
+pub(super) struct ServiceBundle {
+    milvus: Service,
+    telemetry: TelemetryService,
+    generation: TransportGeneration,
+}
+
+pub(super) type SharedServices = Arc<RwLock<ServiceBundle>>;
+
+fn service_bundle(
+    channel: Channel,
+    interceptor: V2Interceptor,
+    generation: TransportGeneration,
+) -> ServiceBundle {
+    ServiceBundle {
+        milvus: MilvusServiceClient::with_interceptor(channel.clone(), interceptor.clone()),
+        telemetry: ClientTelemetryServiceClient::with_interceptor(channel, interceptor),
+        generation,
+    }
+}
 
 fn normalize_database(database: String) -> Result<String> {
     let database = if database.is_empty() {
@@ -197,6 +227,24 @@ impl Interceptor for V2Interceptor {
             })?;
             request.metadata_mut().insert("dbname", value);
         }
+        let request_millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|duration| duration.as_millis().to_string())
+            .unwrap_or_else(|_| "0".to_owned());
+        if let Ok(value) = request_millis.parse() {
+            request
+                .metadata_mut()
+                .insert("client-request-unixmsec", value);
+        }
+        // Only validated lowercase non-zero OTel TraceIDs reach this point. Malformed
+        // caller values are omitted because the server would ignore them as trace IDs.
+        if let Some(request_id) = telemetry::current_client_request_id() {
+            if !request_id.is_empty() {
+                if let Ok(value) = request_id.parse() {
+                    request.metadata_mut().insert("client_request_id", value);
+                }
+            }
+        }
         Ok(request)
     }
 }
@@ -232,13 +280,14 @@ impl Interceptor for V2Interceptor {
 ///   are required.
 #[derive(Clone)]
 pub struct ClientV2 {
-    service: Arc<RwLock<Service>>,
+    service: SharedServices,
     database: Arc<RwLock<String>>,
     rpc_timeout: Arc<RwLock<Duration>>,
     retry: Arc<RwLock<RetryConfig>>,
     cache_endpoint: Arc<String>,
     schema_load_scope: Arc<SchemaLoadScope>,
     global_cluster: Option<Arc<global_cluster::GlobalCluster>>,
+    telemetry: ClientTelemetry,
 }
 
 impl ClientV2 {
@@ -265,10 +314,10 @@ impl ClientV2 {
             let topology = global_cluster::fetch_topology(&param.uri, &param).await?;
             let primary_endpoint = topology.primary()?.endpoint().to_owned();
             let primary_uri = global_cluster::cluster_endpoint_uri(&primary_endpoint, &param)?;
-            let mut service =
-                global_cluster::build_service(&primary_uri, &param, &database).await?;
-            wait_for_server(&mut service, param.connect_timeout).await?;
-            let service = Arc::new(RwLock::new(service));
+            let mut services =
+                global_cluster::build_services(&primary_uri, &param, &database, 0).await?;
+            wait_for_server(&mut services.milvus, param.connect_timeout).await?;
+            let service = Arc::new(RwLock::new(services));
             // The cache endpoint is the global URI itself, resolved with the same
             // scheme-upgrade logic as the plain connection path (an explicit http:// global
             // URI is upgraded to https:// when TLS is enabled) rather than the member-endpoint
@@ -290,15 +339,23 @@ impl ClientV2 {
                 token,
                 database: Arc::clone(&database),
             };
-            let mut service = MilvusServiceClient::with_interceptor(channel, interceptor);
-            wait_for_server(&mut service, param.connect_timeout).await?;
+            let mut services = service_bundle(channel, interceptor, 0);
+            wait_for_server(&mut services.milvus, param.connect_timeout).await?;
             (
-                Arc::new(RwLock::new(service)),
+                Arc::new(RwLock::new(services)),
                 database,
                 Arc::new(effective_endpoint_uri),
                 None,
             )
         };
+
+        let telemetry = ClientTelemetry::new(
+            param.telemetry.clone(),
+            Arc::clone(&service),
+            Arc::clone(&database),
+            &param,
+        );
+        telemetry.start();
 
         Ok(Self {
             service,
@@ -308,6 +365,7 @@ impl ClientV2 {
             cache_endpoint,
             schema_load_scope: Arc::new(SchemaLoadScope::new()),
             global_cluster,
+            telemetry,
         })
     }
 
@@ -319,6 +377,11 @@ impl ClientV2 {
     /// Replaces the retry policy used by subsequent RPC calls.
     pub fn set_retry_param(&self, retry: RetryConfig) {
         *self.retry.write() = retry;
+    }
+
+    /// Returns the shared client-side telemetry manager.
+    pub fn telemetry(&self) -> ClientTelemetry {
+        self.telemetry.clone()
     }
 
     /// Creates a cluster-scoped session view bound to the given cluster identifier.
@@ -372,7 +435,7 @@ impl ClientV2 {
     {
         self.retry_call(
             || {
-                let service = self.service.read().clone();
+                let service = self.service.read().milvus.clone();
                 let request = self.rpc_request(make_request()?);
                 Ok(call(service, request))
             },
@@ -395,7 +458,7 @@ impl ClientV2 {
     {
         self.retry_call(
             || {
-                let service = self.service.read().clone();
+                let service = self.service.read().milvus.clone();
                 let request = if apply_rpc_timeout {
                     self.rpc_request(request.clone())
                 } else {
@@ -764,6 +827,7 @@ fn retry_attempt_timed_out(limit: Duration, attempt: u32) -> Error {
 mod retry_tests {
     use super::*;
     use crate::proto::common;
+    use crate::v2::types::TelemetryConfig;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn client(retry: RetryConfig) -> ClientV2 {
@@ -773,17 +837,23 @@ mod retry_tests {
             token: None,
             database: Arc::clone(&database),
         };
+        let service = Arc::new(RwLock::new(service_bundle(channel, interceptor, 0)));
+        let config = ConnectConfig::new().telemetry(TelemetryConfig::new().enabled(false));
+        let telemetry = ClientTelemetry::new(
+            config.telemetry.clone(),
+            Arc::clone(&service),
+            Arc::clone(&database),
+            &config,
+        );
         ClientV2 {
-            service: Arc::new(RwLock::new(MilvusServiceClient::with_interceptor(
-                channel,
-                interceptor,
-            ))),
+            service,
             database,
             rpc_timeout: Arc::new(RwLock::new(Duration::from_secs(1))),
             retry: Arc::new(RwLock::new(retry)),
             cache_endpoint: Arc::new("http://127.0.0.1:19530".to_owned()),
             schema_load_scope: Arc::new(SchemaLoadScope::new()),
             global_cluster: None,
+            telemetry,
         }
     }
 

--- a/src/v2/client/cdc.rs
+++ b/src/v2/client/cdc.rs
@@ -78,7 +78,7 @@ impl ClientV2 {
     {
         use crate::proto::milvus::dump_messages_response::Response;
 
-        let mut service = self.service.read().clone();
+        let mut service = self.service.read().milvus.clone();
         let mut stream = service
             .dump_messages(tonic::Request::new(request.into_proto()))
             .await?

--- a/src/v2/client/database.rs
+++ b/src/v2/client/database.rs
@@ -27,9 +27,24 @@ impl ClientV2 {
     /// This changes client-side routing metadata; it does not create the database or verify that
     /// it exists. Use [`ClientV2::describe_database`] or a database operation to validate it.
     pub fn use_database(&self, database: impl Into<String>) -> Result<()> {
-        let database = normalize_database(database.into())?;
+        let database = database.into();
+        let explicit = !database.is_empty();
+        let database = normalize_database(database)?;
 
-        *self.database.write() = database;
+        if explicit {
+            // Publish the selected name before declaring it explicit. A concurrent
+            // reader can therefore observe only the old selection or the new one.
+            *self.database.write() = database;
+            self.database_explicit
+                .store(true, std::sync::atomic::Ordering::Release);
+        } else {
+            // Clear explicitness before publishing the normalized default. Reversing
+            // this order could transiently report an omitted database as explicit
+            // `default` while switching from a previously explicit selection.
+            self.database_explicit
+                .store(false, std::sync::atomic::Ordering::Release);
+            *self.database.write() = database;
+        }
         Ok(())
     }
 
@@ -123,16 +138,19 @@ mod tests {
     use crate::v2::error::Error;
     use crate::v2::types::RetryConfig;
     use parking_lot::RwLock;
+    use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use std::time::Duration;
     use tonic::transport::Endpoint;
 
     fn client() -> ClientV2 {
         let database = Arc::new(RwLock::new("default".to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(false));
         let channel = Endpoint::from_static("http://127.0.0.1:19530").connect_lazy();
         let interceptor = super::super::V2Interceptor {
             token: None,
             database: Arc::clone(&database),
+            database_explicit: Arc::clone(&database_explicit),
         };
         let service = Arc::new(RwLock::new(super::super::service_bundle(
             channel,
@@ -145,11 +163,13 @@ mod tests {
             config.telemetry.clone(),
             Arc::clone(&service),
             Arc::clone(&database),
+            Arc::clone(&database_explicit),
             &config,
         );
         ClientV2 {
             service,
             database,
+            database_explicit,
             rpc_timeout: Arc::new(RwLock::new(Duration::from_secs(1))),
             retry: Arc::new(RwLock::new(RetryConfig::new())),
             cache_endpoint: Arc::new("database-tests".to_owned()),
@@ -187,13 +207,62 @@ mod tests {
         *client.database.write() = String::new();
         assert_eq!(client.current_database(), "default");
 
+        client
+            .use_database("default")
+            .expect("select explicit default database");
+        assert!(client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire));
+
         client.use_database("").expect("select default database");
         assert_eq!(client.current_database(), "default");
+        assert!(!client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire));
 
         let error = client
             .use_database("invalid\nname")
             .expect_err("reject invalid database metadata");
         assert!(matches!(error, Error::Validation(_)));
         assert_eq!(client.current_database(), "default");
+    }
+
+    #[tokio::test]
+    async fn use_database_reset_clears_explicitness_before_publishing_default() {
+        let client = client();
+        client
+            .use_database("catalog")
+            .expect("select explicit database");
+
+        // Hold a reader so the reset thread blocks immediately before publishing
+        // the normalized default. It must still be able to clear explicitness first.
+        let selected_database = client.database.read();
+        let reset_client = client.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let reset = std::thread::spawn(move || {
+            started_tx.send(()).expect("signal reset start");
+            reset_client.use_database("").expect("reset database");
+        });
+        started_rx.recv().expect("reset thread started");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reset did not clear explicitness before waiting for the database lock"
+            );
+            std::thread::yield_now();
+        }
+        assert_eq!(selected_database.as_str(), "catalog");
+
+        drop(selected_database);
+        reset.join().expect("reset thread completes");
+        assert_eq!(client.current_database(), "default");
+        assert!(!client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire));
     }
 }

--- a/src/v2/client/database.rs
+++ b/src/v2/client/database.rs
@@ -119,7 +119,6 @@ impl ClientV2 {
 mod tests {
     use super::*;
     use crate::proto::milvus;
-    use crate::proto::milvus::milvus_service_client::MilvusServiceClient;
     use crate::v2::client::cache::SCHEMA_CACHE;
     use crate::v2::error::Error;
     use crate::v2::types::RetryConfig;
@@ -135,17 +134,28 @@ mod tests {
             token: None,
             database: Arc::clone(&database),
         };
+        let service = Arc::new(RwLock::new(super::super::service_bundle(
+            channel,
+            interceptor,
+            0,
+        )));
+        let config = super::super::ConnectConfig::new()
+            .telemetry(crate::v2::types::TelemetryConfig::new().enabled(false));
+        let telemetry = super::super::ClientTelemetry::new(
+            config.telemetry.clone(),
+            Arc::clone(&service),
+            Arc::clone(&database),
+            &config,
+        );
         ClientV2 {
-            service: Arc::new(RwLock::new(MilvusServiceClient::with_interceptor(
-                channel,
-                interceptor,
-            ))),
+            service,
             database,
             rpc_timeout: Arc::new(RwLock::new(Duration::from_secs(1))),
             retry: Arc::new(RwLock::new(RetryConfig::new())),
             cache_endpoint: Arc::new("database-tests".to_owned()),
             schema_load_scope: Arc::new(super::super::cache::SchemaLoadScope::new()),
             global_cluster: None,
+            telemetry,
         }
     }
 

--- a/src/v2/client/dml.rs
+++ b/src/v2/client/dml.rs
@@ -33,54 +33,60 @@ impl ClientV2 {
         &self,
         request: request::dml::InsertRequest,
     ) -> Result<response::dml::InsertResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection_name = request.collection_name.clone();
-        for attempt in 0..2 {
-            let resolved = self
-                .resolve_data(
+        let telemetry = self.telemetry.begin_operation("Insert", &collection_name);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            for attempt in 0..2 {
+                let resolved = self
+                    .resolve_data(
+                        &database,
+                        &collection_name,
+                        &request.columns,
+                        &request.rows,
+                        false,
+                        false,
+                        &[],
+                    )
+                    .await?;
+                let response = self
+                    .retry_rpc(
+                        || {
+                            let fields = resolved.to_proto_fields(
+                                &request.columns,
+                                &request.rows,
+                                false,
+                                false,
+                            )?;
+                            request.to_proto_with_fields(
+                                fields,
+                                resolved.row_count,
+                                resolved.schema_timestamp,
+                                &database,
+                            )
+                        },
+                        RetrySemantics::NonIdempotent,
+                        |mut service, request| async move { service.insert(request).await },
+                        dml_retry_status,
+                    )
+                    .await?;
+                if attempt == 0 && is_schema_mismatch(&response.status) {
+                    self.remove_collection_description(&database, &collection_name);
+                    continue;
+                }
+                status_to_result(&response.status)?;
+                self.update_dml_timestamp(
                     &database,
-                    &collection_name,
-                    &request.columns,
-                    &request.rows,
-                    false,
-                    false,
-                    &[],
-                )
-                .await?;
-            let response = self
-                .retry_rpc(
-                    || {
-                        let fields = resolved.to_proto_fields(
-                            &request.columns,
-                            &request.rows,
-                            false,
-                            false,
-                        )?;
-                        request.to_proto_with_fields(
-                            fields,
-                            resolved.row_count,
-                            resolved.schema_timestamp,
-                            &database,
-                        )
-                    },
-                    RetrySemantics::NonIdempotent,
-                    |mut service, request| async move { service.insert(request).await },
-                    dml_retry_status,
-                )
-                .await?;
-            if attempt == 0 && is_schema_mismatch(&response.status) {
-                self.remove_collection_description(&database, &collection_name);
-                continue;
+                    &resolved.canonical_collection_name,
+                    response.timestamp,
+                );
+                return response::dml::DmlResponse::from_proto(response);
             }
-            status_to_result(&response.status)?;
-            self.update_dml_timestamp(
-                &database,
-                &resolved.canonical_collection_name,
-                response.timestamp,
-            );
-            return response::dml::DmlResponse::from_proto(response);
+            unreachable!("insert schema-mismatch retry loop always returns")
         }
-        unreachable!("insert schema-mismatch retry loop always returns")
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Inserts new entities or updates existing entities in a collection.
@@ -93,75 +99,81 @@ impl ClientV2 {
         &self,
         request: request::dml::UpsertRequest,
     ) -> Result<response::dml::UpsertResponse> {
-        let partial_update = request.is_partial_update();
-        let field_ops = request.field_ops;
-        let request = request.insert;
-        let database = self.effective_database(request.database_name.as_deref());
-        let collection_name = request.collection_name.clone();
-        for attempt in 0..2 {
-            let resolved = self
-                .resolve_data(
+        let collection_name = request.insert.collection_name.clone();
+        let telemetry = self.telemetry.begin_operation("Upsert", &collection_name);
+        let result = async {
+            let partial_update = request.is_partial_update();
+            let field_ops = request.field_ops;
+            let request = request.insert;
+            let database = self.effective_database(request.database_name.as_deref());
+            for attempt in 0..2 {
+                let resolved = self
+                    .resolve_data(
+                        &database,
+                        &collection_name,
+                        &request.columns,
+                        &request.rows,
+                        true,
+                        partial_update,
+                        &field_ops,
+                    )
+                    .await?;
+                let response = self
+                    .retry_rpc(
+                        || {
+                            let fields = resolved.to_proto_fields(
+                                &request.columns,
+                                &request.rows,
+                                true,
+                                partial_update,
+                            )?;
+                            let insert = request.to_proto_with_fields(
+                                fields,
+                                resolved.row_count,
+                                resolved.schema_timestamp,
+                                &database,
+                            )?;
+                            Ok(milvus::UpsertRequest {
+                                base: insert.base,
+                                db_name: insert.db_name,
+                                collection_name: insert.collection_name,
+                                partition_name: insert.partition_name,
+                                fields_data: insert.fields_data,
+                                hash_keys: insert.hash_keys,
+                                num_rows: insert.num_rows,
+                                schema_timestamp: insert.schema_timestamp,
+                                partial_update,
+                                namespace: None,
+                                field_ops: field_ops
+                                    .iter()
+                                    .cloned()
+                                    .map(crate::v2::types::FieldPartialUpdateOp::into_proto)
+                                    .collect(),
+                                ..Default::default()
+                            })
+                        },
+                        RetrySemantics::NonIdempotent,
+                        |mut service, request| async move { service.upsert(request).await },
+                        dml_retry_status,
+                    )
+                    .await?;
+                if attempt == 0 && is_schema_mismatch(&response.status) {
+                    self.remove_collection_description(&database, &collection_name);
+                    continue;
+                }
+                status_to_result(&response.status)?;
+                self.update_dml_timestamp(
                     &database,
-                    &collection_name,
-                    &request.columns,
-                    &request.rows,
-                    true,
-                    partial_update,
-                    &field_ops,
-                )
-                .await?;
-            let response = self
-                .retry_rpc(
-                    || {
-                        let fields = resolved.to_proto_fields(
-                            &request.columns,
-                            &request.rows,
-                            true,
-                            partial_update,
-                        )?;
-                        let insert = request.to_proto_with_fields(
-                            fields,
-                            resolved.row_count,
-                            resolved.schema_timestamp,
-                            &database,
-                        )?;
-                        Ok(milvus::UpsertRequest {
-                            base: insert.base,
-                            db_name: insert.db_name,
-                            collection_name: insert.collection_name,
-                            partition_name: insert.partition_name,
-                            fields_data: insert.fields_data,
-                            hash_keys: insert.hash_keys,
-                            num_rows: insert.num_rows,
-                            schema_timestamp: insert.schema_timestamp,
-                            partial_update,
-                            namespace: None,
-                            field_ops: field_ops
-                                .iter()
-                                .cloned()
-                                .map(crate::v2::types::FieldPartialUpdateOp::into_proto)
-                                .collect(),
-                            ..Default::default()
-                        })
-                    },
-                    RetrySemantics::NonIdempotent,
-                    |mut service, request| async move { service.upsert(request).await },
-                    dml_retry_status,
-                )
-                .await?;
-            if attempt == 0 && is_schema_mismatch(&response.status) {
-                self.remove_collection_description(&database, &collection_name);
-                continue;
+                    &resolved.canonical_collection_name,
+                    response.timestamp,
+                );
+                return response::dml::DmlResponse::from_proto(response);
             }
-            status_to_result(&response.status)?;
-            self.update_dml_timestamp(
-                &database,
-                &resolved.canonical_collection_name,
-                response.timestamp,
-            );
-            return response::dml::DmlResponse::from_proto(response);
+            unreachable!("upsert schema-mismatch retry loop always returns")
         }
-        unreachable!("upsert schema-mismatch retry loop always returns")
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Deletes entities selected by a filter expression or primary-key IDs.
@@ -173,44 +185,50 @@ impl ClientV2 {
         &self,
         request: request::dml::DeleteRequest,
     ) -> Result<response::dml::DeleteResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection_name = request.collection_name.clone();
-        let description = self
-            .get_collection_description(&database, &collection_name)
-            .await?;
-        let canonical_collection_name = if description.collection_name.is_empty() {
-            collection_name.clone()
-        } else {
-            description.collection_name.clone()
-        };
-        let primary_field_name = if request.has_ids() {
-            Some(
-                description
-                    .schema
-                    .as_ref()
-                    .and_then(|schema| schema.fields.iter().find(|field| field.is_primary_key))
-                    .map(|field| field.name.clone())
-                    .ok_or_else(|| {
-                        crate::v2::error::Error::MalformedResponse(
-                            "collection schema has no primary key".into(),
-                        )
-                    })?,
-            )
-        } else {
-            None
-        };
-        let raw = request.into_proto(&database, primary_field_name.as_deref())?;
-        let response = self
-            .retry_rpc(
-                || Ok(raw.clone()),
-                RetrySemantics::NonIdempotent,
-                |mut service, request| async move { service.delete(request).await },
-                |response| response.status.clone(),
-            )
-            .await?;
-        status_to_result(&response.status)?;
-        self.update_dml_timestamp(&database, &canonical_collection_name, response.timestamp);
-        response::dml::DmlResponse::from_proto(response)
+        let telemetry = self.telemetry.begin_operation("Delete", &collection_name);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            let description = self
+                .get_collection_description(&database, &collection_name)
+                .await?;
+            let canonical_collection_name = if description.collection_name.is_empty() {
+                collection_name.clone()
+            } else {
+                description.collection_name.clone()
+            };
+            let primary_field_name = if request.has_ids() {
+                Some(
+                    description
+                        .schema
+                        .as_ref()
+                        .and_then(|schema| schema.fields.iter().find(|field| field.is_primary_key))
+                        .map(|field| field.name.clone())
+                        .ok_or_else(|| {
+                            crate::v2::error::Error::MalformedResponse(
+                                "collection schema has no primary key".into(),
+                            )
+                        })?,
+                )
+            } else {
+                None
+            };
+            let raw = request.into_proto(&database, primary_field_name.as_deref())?;
+            let response = self
+                .retry_rpc(
+                    || Ok(raw.clone()),
+                    RetrySemantics::NonIdempotent,
+                    |mut service, request| async move { service.delete(request).await },
+                    |response| response.status.clone(),
+                )
+                .await?;
+            status_to_result(&response.status)?;
+            self.update_dml_timestamp(&database, &canonical_collection_name, response.timestamp);
+            response::dml::DmlResponse::from_proto(response)
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 }
 

--- a/src/v2/client/dql.rs
+++ b/src/v2/client/dql.rs
@@ -41,21 +41,27 @@ impl ClientV2 {
         request: request::dql::QueryRequest,
         cluster_id: &str,
     ) -> Result<response::dql::QueryResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection = request.collection_name.clone();
-        let guarantee = self
-            .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
-            .await?;
-        let primary_field = if request.ids.is_empty() {
-            None
-        } else {
-            Some(self.primary_field_name(&database, &collection).await?)
-        };
-        let mut raw = request.into_proto(&database, primary_field.as_deref(), guarantee)?;
-        set_cluster_param(&mut raw.query_params, cluster_id);
-        let response = rpc_with_retry!(self, query, raw)?;
-        status_to_result(&response.status)?;
-        response::dql::QueryResponse::from_proto(response)
+        let telemetry = self.telemetry.begin_operation("Query", &collection);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            let guarantee = self
+                .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
+                .await?;
+            let primary_field = if request.ids.is_empty() {
+                None
+            } else {
+                Some(self.primary_field_name(&database, &collection).await?)
+            };
+            let mut raw = request.into_proto(&database, primary_field.as_deref(), guarantee)?;
+            set_cluster_param(&mut raw.query_params, cluster_id);
+            let response = rpc_with_retry!(self, query, raw)?;
+            status_to_result(&response.status)?;
+            response::dql::QueryResponse::from_proto(response)
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Retrieves entities by their primary-key values.
@@ -75,17 +81,23 @@ impl ClientV2 {
         request: request::dql::GetRequest,
         cluster_id: &str,
     ) -> Result<response::dql::GetResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection = request.collection_name.clone();
-        let guarantee = self
-            .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
-            .await?;
-        let primary_field = self.primary_field_name(&database, &collection).await?;
-        let mut raw = request.into_proto(&database, &primary_field, guarantee)?;
-        set_cluster_param(&mut raw.query_params, cluster_id);
-        let response = rpc_with_retry!(self, query, raw)?;
-        status_to_result(&response.status)?;
-        response::dql::QueryResponse::from_proto(response)
+        let telemetry = self.telemetry.begin_operation("Query", &collection);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            let guarantee = self
+                .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
+                .await?;
+            let primary_field = self.primary_field_name(&database, &collection).await?;
+            let mut raw = request.into_proto(&database, &primary_field, guarantee)?;
+            set_cluster_param(&mut raw.query_params, cluster_id);
+            let response = rpc_with_retry!(self, query, raw)?;
+            status_to_result(&response.status)?;
+            response::dql::QueryResponse::from_proto(response)
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Searches vector fields and returns ranked hits for each query vector.
@@ -105,16 +117,22 @@ impl ClientV2 {
         request: request::dql::SearchRequest,
         cluster_id: &str,
     ) -> Result<response::dql::SearchResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection = request.collection_name.clone();
-        let guarantee = self
-            .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
-            .await?;
-        let mut raw = request.into_proto(&database, guarantee)?;
-        set_cluster_param(&mut raw.search_params, cluster_id);
-        let response = rpc_with_retry!(self, search, raw)?;
-        status_to_result(&response.status)?;
-        response::dql::SearchResponse::from_proto(response)
+        let telemetry = self.telemetry.begin_operation("Search", &collection);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            let guarantee = self
+                .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
+                .await?;
+            let mut raw = request.into_proto(&database, guarantee)?;
+            set_cluster_param(&mut raw.search_params, cluster_id);
+            let response = rpc_with_retry!(self, search, raw)?;
+            status_to_result(&response.status)?;
+            response::dql::SearchResponse::from_proto(response)
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Executes multiple vector searches and combines them with the requested reranking strategy.
@@ -133,16 +151,22 @@ impl ClientV2 {
         request: request::dql::HybridSearchRequest,
         cluster_id: &str,
     ) -> Result<response::dql::HybridSearchResponse> {
-        let database = self.effective_database(request.database_name.as_deref());
         let collection = request.collection_name.clone();
-        let guarantee = self
-            .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
-            .await?;
-        let mut raw = request.into_proto(&database, guarantee)?;
-        set_cluster_param(&mut raw.rank_params, cluster_id);
-        let response = rpc_with_retry!(self, hybrid_search, raw)?;
-        status_to_result(&response.status)?;
-        response::dql::SearchResponse::from_proto(response)
+        let telemetry = self.telemetry.begin_operation("HybridSearch", &collection);
+        let result = async {
+            let database = self.effective_database(request.database_name.as_deref());
+            let guarantee = self
+                .deduce_guarantee_timestamp(&database, &collection, request.consistency_level)
+                .await?;
+            let mut raw = request.into_proto(&database, guarantee)?;
+            set_cluster_param(&mut raw.rank_params, cluster_id);
+            let response = rpc_with_retry!(self, hybrid_search, raw)?;
+            status_to_result(&response.status)?;
+            response::dql::SearchResponse::from_proto(response)
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     async fn primary_field_name(&self, database: &str, collection: &str) -> Result<String> {

--- a/src/v2/client/global_cluster.rs
+++ b/src/v2/client/global_cluster.rs
@@ -25,6 +25,7 @@ use crate::v2::error::{Error, Result};
 use crate::v2::types::{topology_url, GlobalTopology};
 use parking_lot::RwLock;
 use reqwest::{Client, StatusCode};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -330,6 +331,7 @@ pub(crate) async fn build_services(
     endpoint_uri: &str,
     connect_config: &super::ConnectConfig,
     database: &Arc<RwLock<String>>,
+    database_explicit: &Arc<AtomicBool>,
     generation: TransportGeneration,
 ) -> Result<ServiceBundle> {
     let endpoint = super::build_endpoint(endpoint_uri, connect_config).await?;
@@ -345,6 +347,7 @@ pub(crate) async fn build_services(
     let interceptor = V2Interceptor {
         token,
         database: Arc::clone(database),
+        database_explicit: Arc::clone(database_explicit),
     };
     Ok(super::service_bundle(channel, interceptor, generation))
 }
@@ -360,6 +363,7 @@ pub(crate) struct GlobalCluster {
     global_endpoint: String,
     connect_config: super::ConnectConfig,
     database: Arc<RwLock<String>>,
+    database_explicit: Arc<AtomicBool>,
     service: SharedServices,
     topology: RwLock<GlobalTopology>,
     last_unavailable_probe: std::sync::Mutex<Option<std::time::Instant>>,
@@ -373,6 +377,7 @@ impl GlobalCluster {
         global_endpoint: String,
         connect_config: super::ConnectConfig,
         database: Arc<RwLock<String>>,
+        database_explicit: Arc<AtomicBool>,
         service: SharedServices,
         topology: GlobalTopology,
     ) -> Self {
@@ -380,6 +385,7 @@ impl GlobalCluster {
             global_endpoint,
             connect_config,
             database,
+            database_explicit,
             service,
             topology: RwLock::new(topology),
             last_unavailable_probe: std::sync::Mutex::new(None),
@@ -624,6 +630,7 @@ impl GlobalCluster {
             &endpoint_uri,
             &self.connect_config,
             &self.database,
+            &self.database_explicit,
             generation,
         )
         .await
@@ -840,6 +847,7 @@ mod tests {
     ) -> StdArc<GlobalCluster> {
         let config = super::super::ConnectConfig::new().uri("http://global:19530");
         let database = Arc::new(RwLock::new("default".to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(false));
         let topology = parse_topology_response(initial_body).expect("initial topology");
         let primary = topology
             .primary()
@@ -851,6 +859,7 @@ mod tests {
                 &cluster_endpoint_uri(&primary, &config).expect("initial primary uri"),
                 &config,
                 &database,
+                &database_explicit,
                 0,
             )
             .await
@@ -860,6 +869,7 @@ mod tests {
             server.endpoint(),
             config,
             database,
+            database_explicit,
             service,
             topology,
         ))

--- a/src/v2/client/global_cluster.rs
+++ b/src/v2/client/global_cluster.rs
@@ -20,8 +20,7 @@
 //! topology of member clusters. This module fetches that topology, resolves the writable primary,
 //! and rebuilds the gRPC channel when the primary endpoint changes.
 
-use super::{Service, V2Interceptor};
-use crate::proto::milvus::milvus_service_client::MilvusServiceClient;
+use super::{ServiceBundle, SharedServices, TransportGeneration, V2Interceptor};
 use crate::v2::error::{Error, Result};
 use crate::v2::types::{topology_url, GlobalTopology};
 use parking_lot::RwLock;
@@ -327,11 +326,12 @@ async fn build_topology_tls_config(
 ///
 /// The channel is created lazily; `wait_for_server` on the caller performs the
 /// initial connectivity check.
-pub(crate) async fn build_service(
+pub(crate) async fn build_services(
     endpoint_uri: &str,
     connect_config: &super::ConnectConfig,
     database: &Arc<RwLock<String>>,
-) -> Result<Service> {
+    generation: TransportGeneration,
+) -> Result<ServiceBundle> {
     let endpoint = super::build_endpoint(endpoint_uri, connect_config).await?;
     let channel = endpoint.connect_lazy();
     let token = connect_config
@@ -346,7 +346,7 @@ pub(crate) async fn build_service(
         token,
         database: Arc::clone(database),
     };
-    Ok(MilvusServiceClient::with_interceptor(channel, interceptor))
+    Ok(super::service_bundle(channel, interceptor, generation))
 }
 
 /// Shared global-cluster state that manages topology discovery and primary failover.
@@ -360,7 +360,7 @@ pub(crate) struct GlobalCluster {
     global_endpoint: String,
     connect_config: super::ConnectConfig,
     database: Arc<RwLock<String>>,
-    service: Arc<RwLock<Service>>,
+    service: SharedServices,
     topology: RwLock<GlobalTopology>,
     last_unavailable_probe: std::sync::Mutex<Option<std::time::Instant>>,
     probe_in_progress: std::sync::atomic::AtomicBool,
@@ -373,7 +373,7 @@ impl GlobalCluster {
         global_endpoint: String,
         connect_config: super::ConnectConfig,
         database: Arc<RwLock<String>>,
-        service: Arc<RwLock<Service>>,
+        service: SharedServices,
         topology: GlobalTopology,
     ) -> Self {
         Self {
@@ -619,13 +619,21 @@ impl GlobalCluster {
                 return false;
             }
         };
-        match build_service(&endpoint_uri, &self.connect_config, &self.database).await {
-            Ok(mut service) => {
+        let generation = self.service.read().generation.saturating_add(1);
+        match build_services(
+            &endpoint_uri,
+            &self.connect_config,
+            &self.database,
+            generation,
+        )
+        .await
+        {
+            Ok(mut services) => {
                 // A TCP connect alone does not prove the endpoint is ready to serve gRPC, so
                 // perform the same bounded Connect handshake the initial connection uses before
                 // committing the new primary; a plain-HTTP load balancer or still-starting service
                 // is rejected instead of being committed and cycling UNAVAILABLE failures.
-                if super::wait_for_server(&mut service, self.connect_config.connect_timeout)
+                if super::wait_for_server(&mut services.milvus, self.connect_config.connect_timeout)
                     .await
                     .is_err()
                 {
@@ -634,7 +642,7 @@ impl GlobalCluster {
                         "member endpoint did not complete the gRPC Connect handshake; keeping previous primary");
                     return false;
                 }
-                *self.service.write() = service;
+                *self.service.write() = services;
                 true
             }
             Err(error) => {
@@ -839,10 +847,11 @@ mod tests {
             .endpoint()
             .to_owned();
         let service = Arc::new(RwLock::new(
-            build_service(
+            build_services(
                 &cluster_endpoint_uri(&primary, &config).expect("initial primary uri"),
                 &config,
                 &database,
+                0,
             )
             .await
             .expect("build initial service"),

--- a/src/v2/client/telemetry.rs
+++ b/src/v2/client/telemetry.rs
@@ -1,0 +1,1943 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Client-side operation telemetry, heartbeat delivery, and server commands.
+
+use super::SharedServices;
+use crate::proto::{common, milvus};
+use crate::v2::error::status_to_result;
+use crate::v2::types::{ConnectConfig, TelemetryConfig};
+use chrono::{DateTime, Utc};
+use parking_lot::{Mutex, RwLock};
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio_util::sync::CancellationToken;
+use tonic::{Code, Request};
+use uuid::Uuid;
+
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_UNSUPPORTED_BACKOFF: Duration = Duration::from_secs(30 * 60);
+const LATENCY_SAMPLE_CAPACITY: usize = 1000;
+const MAX_REPLY_PAYLOAD_SIZE: usize = 1024 * 1024;
+const HISTORY_RETENTION: Duration = Duration::from_secs(60 * 60);
+const MAX_HISTORY_SNAPSHOTS: usize = 3600;
+const SAMPLING_SCALE: u64 = 1_000_000_000;
+
+tokio::task_local! {
+    static CLIENT_REQUEST_ID: String;
+}
+
+/// Runs a future with a caller-provided `client_request_id`.
+///
+/// The ID must be a non-zero, 32-character lowercase OpenTelemetry TraceID.
+/// Malformed values are omitted from both gRPC metadata and telemetry error
+/// correlation because the server would reject them as trace identifiers.
+pub async fn with_client_request_id<F>(request_id: impl Into<String>, future: F) -> F::Output
+where
+    F: Future,
+{
+    CLIENT_REQUEST_ID.scope(request_id.into(), future).await
+}
+
+/// Generates a non-zero lowercase 32-character OpenTelemetry TraceID.
+pub fn new_client_request_id() -> String {
+    Uuid::new_v4().simple().to_string()
+}
+
+pub(super) fn current_client_request_id() -> Option<String> {
+    CLIENT_REQUEST_ID
+        .try_with(Clone::clone)
+        .ok()
+        .filter(|value| valid_trace_id(value))
+}
+
+fn valid_trace_id(value: &str) -> bool {
+    value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && value.bytes().any(|byte| byte != b'0')
+}
+
+fn current_telemetry_trace_id() -> String {
+    current_client_request_id().unwrap_or_default()
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Aggregated telemetry for one operation or collection.
+pub struct TelemetryMetrics {
+    /// Number of completed logical calls.
+    pub request_count: i64,
+    /// Number of successful logical calls.
+    pub success_count: i64,
+    /// Number of failed logical calls.
+    pub error_count: i64,
+    /// Mean end-to-end latency in milliseconds.
+    pub avg_latency_ms: f64,
+    /// P99 end-to-end latency in milliseconds.
+    pub p99_latency_ms: f64,
+    /// Maximum end-to-end latency in milliseconds.
+    pub max_latency_ms: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// Metrics for one logical SDK operation.
+pub struct TelemetryOperationMetrics {
+    /// Canonical operation name.
+    pub operation: String,
+    /// Global metrics for the operation.
+    pub global: TelemetryMetrics,
+    /// Optional per-collection metrics.
+    pub collections: BTreeMap<String, TelemetryMetrics>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// One telemetry metrics window.
+pub struct TelemetrySnapshot {
+    /// Inclusive window start in Unix milliseconds.
+    pub timestamp: i64,
+    /// Inclusive window end in Unix milliseconds.
+    pub end_time: i64,
+    /// Operation metrics captured in the window.
+    pub metrics: Vec<TelemetryOperationMetrics>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// A recent client-side operation error.
+pub struct TelemetryErrorInfo {
+    /// Unix timestamp in milliseconds.
+    pub timestamp: i64,
+    /// Canonical operation name.
+    pub operation: String,
+    /// Error text.
+    #[serde(rename = "error_msg")]
+    pub error_message: String,
+    /// Collection associated with the call.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub collection: String,
+    /// Valid OpenTelemetry TraceID associated with the call.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub request_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A server command in the client-side command registry.
+pub struct ClientTelemetryCommand {
+    /// Server-assigned command identifier.
+    pub command_id: String,
+    /// Free-form command type.
+    pub command_type: String,
+    /// Raw JSON payload.
+    pub payload: Vec<u8>,
+    /// Server creation timestamp in Unix milliseconds.
+    pub create_time: i64,
+    /// Whether the command is a persistent configuration.
+    pub persistent: bool,
+    /// Server-computed targeting scope.
+    pub target_scope: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// Reply produced by a client telemetry command handler.
+pub struct ClientTelemetryCommandReply {
+    /// Command identifier being answered.
+    pub command_id: String,
+    /// Whether handling succeeded.
+    pub success: bool,
+    /// Error text when handling failed.
+    pub error_message: String,
+    /// Raw JSON reply payload.
+    pub payload: Vec<u8>,
+}
+
+impl ClientTelemetryCommandReply {
+    fn success(command_id: impl Into<String>, payload: Vec<u8>) -> Self {
+        Self {
+            command_id: command_id.into(),
+            success: true,
+            error_message: String::new(),
+            payload,
+        }
+    }
+
+    fn failure(command_id: impl Into<String>, error_message: impl Into<String>) -> Self {
+        Self {
+            command_id: command_id.into(),
+            success: false,
+            error_message: error_message.into(),
+            payload: Vec::new(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct MetricBucket {
+    request_count: i64,
+    success_count: i64,
+    error_count: i64,
+    total_latency_us: i128,
+    max_latency_us: i64,
+    samples: VecDeque<i64>,
+}
+
+impl MetricBucket {
+    fn record(&mut self, latency_us: i64, success: bool) {
+        self.request_count += 1;
+        self.success_count += i64::from(success);
+        self.error_count += i64::from(!success);
+        self.total_latency_us += i128::from(latency_us);
+        self.max_latency_us = self.max_latency_us.max(latency_us);
+        if self.samples.len() == LATENCY_SAMPLE_CAPACITY {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(latency_us);
+    }
+
+    fn take(&mut self) -> Option<TelemetryMetrics> {
+        if self.request_count == 0 {
+            return None;
+        }
+        let mut samples: Vec<_> = self.samples.iter().copied().collect();
+        samples.sort_unstable();
+        let p99_index = ((samples.len() as f64) * 0.99) as usize;
+        let p99_us = samples[p99_index.min(samples.len() - 1)];
+        let metrics = TelemetryMetrics {
+            request_count: self.request_count,
+            success_count: self.success_count,
+            error_count: self.error_count,
+            avg_latency_ms: self.total_latency_us as f64 / self.request_count as f64 / 1000.0,
+            p99_latency_ms: p99_us as f64 / 1000.0,
+            max_latency_ms: self.max_latency_us as f64 / 1000.0,
+        };
+        *self = Self::default();
+        Some(metrics)
+    }
+}
+
+#[derive(Default)]
+struct OperationCollector {
+    global: MetricBucket,
+    collections: BTreeMap<String, MetricBucket>,
+}
+
+impl OperationCollector {
+    fn record(&mut self, collection: Option<&str>, latency_us: i64, success: bool) {
+        self.global.record(latency_us, success);
+        if let Some(collection) = collection {
+            self.collections
+                .entry(collection.to_owned())
+                .or_default()
+                .record(latency_us, success);
+        }
+    }
+
+    fn take(&mut self, operation: String) -> Option<TelemetryOperationMetrics> {
+        let global = self.global.take()?;
+        let mut collections = BTreeMap::new();
+        for (name, bucket) in &mut self.collections {
+            if let Some(metrics) = bucket.take() {
+                collections.insert(name.clone(), metrics);
+            }
+        }
+        self.collections
+            .retain(|_, bucket| bucket.request_count != 0);
+        Some(TelemetryOperationMetrics {
+            operation,
+            global,
+            collections,
+        })
+    }
+}
+
+type CommandHandler = dyn Fn(&ClientTelemetryCommand) -> ClientTelemetryCommandReply + Send + Sync;
+
+struct RuntimeState {
+    config: TelemetryConfig,
+    collectors: BTreeMap<String, OperationCollector>,
+    snapshots: VecDeque<TelemetrySnapshot>,
+    last_snapshot_end: i64,
+    errors: VecDeque<TelemetryErrorInfo>,
+    enabled_collections: BTreeSet<String>,
+    all_collections_enabled: bool,
+    pending_replies: VecDeque<common::CommandReply>,
+    config_hash: String,
+    last_command_timestamp: i64,
+    executed_commands: HashMap<String, i64>,
+    sampling_accumulator: u64,
+}
+
+impl RuntimeState {
+    fn new(mut config: TelemetryConfig) -> Self {
+        if config.heartbeat_interval.is_zero() {
+            config.heartbeat_interval = DEFAULT_HEARTBEAT_INTERVAL;
+        }
+        if !config.sampling_rate.is_finite() {
+            config.sampling_rate = 0.0;
+        }
+        config.sampling_rate = config.sampling_rate.clamp(0.0, 1.0);
+        if config.error_max_count == 0 {
+            config.error_max_count = 100;
+        }
+        Self {
+            config,
+            collectors: BTreeMap::new(),
+            snapshots: VecDeque::new(),
+            last_snapshot_end: 0,
+            errors: VecDeque::new(),
+            enabled_collections: BTreeSet::new(),
+            all_collections_enabled: false,
+            pending_replies: VecDeque::new(),
+            config_hash: String::new(),
+            last_command_timestamp: 0,
+            executed_commands: HashMap::new(),
+            sampling_accumulator: 0,
+        }
+    }
+
+    fn should_sample(&mut self) -> bool {
+        let rate = self.config.sampling_rate;
+        if rate >= 1.0 {
+            return true;
+        }
+        if rate <= 0.0 {
+            return false;
+        }
+        let step = ((rate * SAMPLING_SCALE as f64) as u64).max(1);
+        self.sampling_accumulator += step;
+        if self.sampling_accumulator >= SAMPLING_SCALE {
+            self.sampling_accumulator -= SAMPLING_SCALE;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+struct ClientConfigSnapshot {
+    uri: String,
+    username: String,
+    initial_database: String,
+    tls_enabled: bool,
+    retry_max_attempts: u32,
+    retry_max_backoff_ms: u64,
+}
+
+struct TelemetryInner {
+    state: Mutex<RuntimeState>,
+    command_handlers: RwLock<HashMap<String, Arc<CommandHandler>>>,
+    command_lock: Mutex<()>,
+    services: SharedServices,
+    database: Arc<RwLock<String>>,
+    client_config: ClientConfigSnapshot,
+    client_id: String,
+    client_id_stable: bool,
+    unsupported_streak: AtomicU64,
+    last_heartbeat_error: RwLock<Option<String>>,
+    shutdown: CancellationToken,
+}
+
+impl Drop for TelemetryInner {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
+}
+
+/// Shared client-side telemetry manager.
+#[derive(Clone)]
+pub struct ClientTelemetry {
+    inner: Arc<TelemetryInner>,
+}
+
+impl ClientTelemetry {
+    pub(super) fn new(
+        config: TelemetryConfig,
+        services: SharedServices,
+        database: Arc<RwLock<String>>,
+        connect: &ConnectConfig,
+    ) -> Self {
+        let client_id_stable = !config.client_id.is_empty();
+        let client_id = if client_id_stable {
+            config.client_id.clone()
+        } else {
+            Uuid::new_v4().to_string()
+        };
+        let username = connect
+            .raw_token()
+            .and_then(|token| token.split_once(':').map(|(user, _)| user.to_owned()))
+            .unwrap_or_default();
+        let inner = TelemetryInner {
+            state: Mutex::new(RuntimeState::new(config)),
+            command_handlers: RwLock::new(HashMap::new()),
+            command_lock: Mutex::new(()),
+            services,
+            database,
+            client_config: ClientConfigSnapshot {
+                uri: connect.uri.clone(),
+                username,
+                initial_database: connect.database.clone(),
+                tls_enabled: super::tls_enabled(connect),
+                retry_max_attempts: connect.retry.max_attempts,
+                retry_max_backoff_ms: connect.retry.max_backoff.as_millis().min(u64::MAX as u128)
+                    as u64,
+            },
+            client_id,
+            client_id_stable,
+            unsupported_streak: AtomicU64::new(0),
+            last_heartbeat_error: RwLock::new(None),
+            shutdown: CancellationToken::new(),
+        };
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Returns the stable runtime client identifier sent in heartbeats.
+    pub fn client_id(&self) -> &str {
+        &self.inner.client_id
+    }
+
+    /// Returns the current effective telemetry configuration.
+    pub fn config(&self) -> TelemetryConfig {
+        self.inner.state.lock().config.clone()
+    }
+
+    /// Reports whether the server is not currently known to reject telemetry as unimplemented.
+    pub fn is_supported(&self) -> bool {
+        self.inner.unsupported_streak.load(Ordering::Relaxed) == 0
+    }
+
+    /// Returns the most recent best-effort heartbeat failure.
+    pub fn last_heartbeat_error(&self) -> Option<String> {
+        self.inner.last_heartbeat_error.read().clone()
+    }
+
+    /// Returns recent operation errors, newest first.
+    pub fn recent_errors(&self, max_count: usize) -> Vec<TelemetryErrorInfo> {
+        self.inner
+            .state
+            .lock()
+            .errors
+            .iter()
+            .rev()
+            .take(max_count)
+            .cloned()
+            .collect()
+    }
+
+    /// Returns retained metric snapshots in chronological order.
+    pub fn snapshots(&self) -> Vec<TelemetrySnapshot> {
+        self.inner.state.lock().snapshots.iter().cloned().collect()
+    }
+
+    /// Registers or replaces a custom command handler.
+    pub fn register_command_handler<F>(&self, command_type: impl Into<String>, handler: F)
+    where
+        F: Fn(&ClientTelemetryCommand) -> ClientTelemetryCommandReply + Send + Sync + 'static,
+    {
+        self.inner
+            .command_handlers
+            .write()
+            .insert(command_type.into(), Arc::new(handler));
+    }
+
+    pub(super) fn start(&self) {
+        if !self.inner.state.lock().config.enabled {
+            return;
+        }
+        let weak = Arc::downgrade(&self.inner);
+        tokio::spawn(async move { heartbeat_loop(weak).await });
+    }
+
+    pub(super) fn begin_operation(
+        &self,
+        operation: &'static str,
+        collection: impl Into<String>,
+    ) -> TelemetryOperationGuard {
+        TelemetryOperationGuard {
+            telemetry: self.clone(),
+            operation,
+            collection: collection.into(),
+            request_id: current_telemetry_trace_id(),
+            started: Instant::now(),
+        }
+    }
+}
+
+pub(super) struct TelemetryOperationGuard {
+    telemetry: ClientTelemetry,
+    operation: &'static str,
+    collection: String,
+    request_id: String,
+    started: Instant,
+}
+
+impl TelemetryOperationGuard {
+    pub(super) fn finish<T>(&self, result: &crate::v2::error::Result<T>) {
+        self.telemetry.inner.record_operation(
+            self.operation,
+            &self.collection,
+            &self.request_id,
+            self.started.elapsed(),
+            result.as_ref().err().map(ToString::to_string),
+        );
+    }
+}
+
+impl TelemetryInner {
+    fn record_operation(
+        &self,
+        operation: &str,
+        collection: &str,
+        request_id: &str,
+        latency: Duration,
+        error: Option<String>,
+    ) {
+        let mut state = self.state.lock();
+        if !state.config.enabled || !state.should_sample() {
+            return;
+        }
+        let collection_enabled = !collection.is_empty()
+            && (state.all_collections_enabled || state.enabled_collections.contains(collection));
+        let latency_us = latency.as_micros().min(i64::MAX as u128) as i64;
+        state
+            .collectors
+            .entry(operation.to_owned())
+            .or_default()
+            .record(
+                collection_enabled.then_some(collection),
+                latency_us,
+                error.is_none(),
+            );
+        if let Some(error_message) = error {
+            let capacity = state.config.error_max_count.max(1);
+            if state.errors.len() == capacity {
+                state.errors.pop_front();
+            }
+            state.errors.push_back(TelemetryErrorInfo {
+                timestamp: now_millis(),
+                operation: operation.to_owned(),
+                error_message,
+                collection: collection.to_owned(),
+                request_id: request_id.to_owned(),
+            });
+        }
+    }
+
+    fn create_snapshot(&self) {
+        let mut state = self.state.lock();
+        if !state.config.enabled {
+            return;
+        }
+        let now = now_millis();
+        let interval_ms = state
+            .config
+            .heartbeat_interval
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        let start = if state.last_snapshot_end == 0 || state.last_snapshot_end > now {
+            now.saturating_sub(interval_ms)
+        } else {
+            state.last_snapshot_end
+        };
+        state.last_snapshot_end = now;
+
+        let mut metrics = Vec::new();
+        for (operation, collector) in &mut state.collectors {
+            if let Some(metric) = collector.take(operation.clone()) {
+                metrics.push(metric);
+            }
+        }
+        state.snapshots.push_back(TelemetrySnapshot {
+            timestamp: start,
+            end_time: now,
+            metrics,
+        });
+
+        let oldest = now.saturating_sub(HISTORY_RETENTION.as_millis() as i64);
+        while state
+            .snapshots
+            .front()
+            .is_some_and(|snapshot| snapshot.end_time < oldest)
+        {
+            state.snapshots.pop_front();
+        }
+        while state.snapshots.len() > MAX_HISTORY_SNAPSHOTS {
+            state.snapshots.pop_front();
+        }
+    }
+
+    fn next_heartbeat_delay(&self) -> Duration {
+        let interval = self.state.lock().config.heartbeat_interval;
+        let streak = self.unsupported_streak.load(Ordering::Relaxed);
+        if streak == 0 {
+            return interval;
+        }
+        let mut backoff = interval;
+        for _ in 0..streak {
+            backoff = backoff.saturating_mul(2);
+            if backoff >= MAX_UNSUPPORTED_BACKOFF {
+                backoff = MAX_UNSUPPORTED_BACKOFF;
+                break;
+            }
+        }
+        backoff.max(interval)
+    }
+
+    fn build_client_info(&self) -> common::ClientInfo {
+        let host = hostname::get()
+            .ok()
+            .and_then(|host| host.into_string().ok())
+            .unwrap_or_default();
+        let mut reserved = HashMap::from([
+            ("client_id".to_owned(), self.client_id.clone()),
+            (
+                "client_id_stable".to_owned(),
+                self.client_id_stable.to_string(),
+            ),
+        ]);
+        let database = self.database.read().clone();
+        // ClientV2 normalizes an omitted database to `default` internally. Do not turn
+        // that implementation detail into an explicit database declaration on the wire.
+        if !database.is_empty() && database != "default" {
+            reserved.insert("db_name".to_owned(), database);
+        }
+        common::ClientInfo {
+            sdk_type: "RustMilvusClient".to_owned(),
+            sdk_version: env!("CARGO_PKG_VERSION").to_owned(),
+            local_time: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
+            user: self.client_config.username.clone(),
+            host,
+            reserved,
+        }
+    }
+
+    fn heartbeat_request(&self) -> milvus::ClientHeartbeatRequest {
+        let state = self.state.lock();
+        let enabled_collections = &state.enabled_collections;
+        let all_collections_enabled = state.all_collections_enabled;
+        let metrics = state
+            .snapshots
+            .back()
+            .map(|snapshot| {
+                snapshot
+                    .metrics
+                    .iter()
+                    .map(|operation| common::OperationMetrics {
+                        operation: operation.operation.clone(),
+                        global: Some(metrics_to_proto(&operation.global)),
+                        collection_metrics: operation
+                            .collections
+                            .iter()
+                            .filter(|(name, _)| {
+                                all_collections_enabled || enabled_collections.contains(*name)
+                            })
+                            .map(|(name, metrics)| (name.clone(), metrics_to_proto(metrics)))
+                            .collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        milvus::ClientHeartbeatRequest {
+            client_info: Some(self.build_client_info()),
+            report_timestamp: now_millis(),
+            metrics,
+            command_replies: state.pending_replies.iter().cloned().collect(),
+            config_hash: state.config_hash.clone(),
+            last_command_timestamp: state.last_command_timestamp,
+        }
+    }
+
+    async fn send_heartbeat(&self) {
+        if !self.state.lock().config.enabled {
+            return;
+        }
+        let request = self.heartbeat_request();
+        let reply_count = request.command_replies.len();
+        let (mut service, generation) = {
+            let bundle = self.services.read();
+            (bundle.telemetry.clone(), bundle.generation)
+        };
+        let mut request = Request::new(request);
+        request.set_timeout(HEARTBEAT_TIMEOUT);
+        let outcome =
+            tokio::time::timeout(HEARTBEAT_TIMEOUT, service.client_heartbeat(request)).await;
+
+        // A global-cluster failover may replace both stubs while this RPC is in flight.
+        // Every result from the retired generation is discarded, including errors, so it
+        // cannot clear replies, alter backoff, or execute stale commands.
+        // Hold the generation read lock through the internal acceptance commit. A failover
+        // that was already published makes the response stale; one that publishes after this
+        // point is ordered after the accepted response and must not retroactively invalidate it.
+        let generation_guard = self.services.read();
+        if generation_guard.generation != generation {
+            return;
+        }
+
+        let response = match outcome {
+            Err(_) => {
+                *self.last_heartbeat_error.write() =
+                    Some("client telemetry heartbeat timed out".to_owned());
+                return;
+            }
+            Ok(Err(status)) => {
+                if status.code() == Code::Unimplemented {
+                    self.unsupported_streak.fetch_add(1, Ordering::Relaxed);
+                }
+                *self.last_heartbeat_error.write() = Some(status.to_string());
+                return;
+            }
+            Ok(Ok(response)) => response.into_inner(),
+        };
+
+        // Any actual RPC response proves that this transport implements the service,
+        // even when the response carries a business failure.
+        self.unsupported_streak.store(0, Ordering::Relaxed);
+        if let Err(error) = status_to_result(&response.status) {
+            *self.last_heartbeat_error.write() = Some(error.to_string());
+            return;
+        }
+        *self.last_heartbeat_error.write() = None;
+
+        {
+            let mut state = self.state.lock();
+            for _ in 0..reply_count.min(state.pending_replies.len()) {
+                state.pending_replies.pop_front();
+            }
+        }
+        let commands = response.commands;
+        // Command handlers are user-extensible and may call normal client APIs. Do not hold
+        // the service-generation lock while invoking them: an API retry may need the write
+        // side of this same lock to publish a global-cluster failover.
+        drop(generation_guard);
+        self.process_commands(commands);
+    }
+
+    fn process_commands(&self, commands: Vec<common::ClientCommand>) {
+        let _command_guard = self.command_lock.lock();
+        self.process_commands_locked(commands);
+    }
+
+    fn process_commands_locked(&self, commands: Vec<common::ClientCommand>) {
+        let (last_timestamp, mut max_timestamp) = {
+            let state = self.state.lock();
+            (state.last_command_timestamp, state.last_command_timestamp)
+        };
+        let has_persistent = commands.iter().any(|command| command.persistent);
+
+        for command in &commands {
+            max_timestamp = max_timestamp.max(command.create_time);
+            let local = ClientTelemetryCommand {
+                command_id: command.command_id.clone(),
+                command_type: command.command_type.clone(),
+                payload: command.payload.clone(),
+                create_time: command.create_time,
+                persistent: command.persistent,
+                target_scope: command.target_scope.clone(),
+            };
+
+            let already_executed = {
+                let state = self.state.lock();
+                command.create_time < last_timestamp
+                    || state.executed_commands.contains_key(&command.command_id)
+            };
+            if already_executed {
+                self.state
+                    .lock()
+                    .pending_replies
+                    .push_back(common::CommandReply {
+                        command_id: command.command_id.clone(),
+                        success: true,
+                        error_message: String::new(),
+                        payload: Vec::new(),
+                    });
+                continue;
+            }
+
+            let reply = self.handle_command(&local);
+            let mut state = self.state.lock();
+            state
+                .executed_commands
+                .insert(command.command_id.clone(), command.create_time);
+            state.pending_replies.push_back(common::CommandReply {
+                command_id: reply.command_id,
+                success: reply.success,
+                error_message: reply.error_message,
+                payload: reply.payload,
+            });
+        }
+
+        let mut state = self.state.lock();
+        // Equal-timestamp IDs must remain: the server's timestamp comparison is strict,
+        // so the same command can be returned repeatedly at the cursor.
+        state
+            .executed_commands
+            .retain(|_, timestamp| *timestamp >= max_timestamp);
+        if has_persistent {
+            state.config_hash = calculate_config_hash(&commands);
+        }
+        if max_timestamp > state.last_command_timestamp {
+            state.last_command_timestamp = max_timestamp;
+        }
+    }
+
+    fn handle_command(&self, command: &ClientTelemetryCommand) -> ClientTelemetryCommandReply {
+        match command.command_type.as_str() {
+            "push_config" => self.handle_push_config(command),
+            "collection_metrics" => self.handle_collection_metrics(command),
+            "show_errors" => self.handle_show_errors(command),
+            "show_latency_history" => self.handle_show_latency_history(command),
+            "get_config" => self.handle_get_config(command),
+            command_type => {
+                // Clone under the read lock, then explicitly release it before calling
+                // user code. A custom handler may register another handler itself.
+                let handler = self.command_handlers.read().get(command_type).cloned();
+                handler.map(|handler| handler(command)).unwrap_or_else(|| {
+                    ClientTelemetryCommandReply::failure(
+                        &command.command_id,
+                        format!("unknown command type: {command_type}"),
+                    )
+                })
+            }
+        }
+    }
+
+    fn handle_push_config(&self, command: &ClientTelemetryCommand) -> ClientTelemetryCommandReply {
+        let object = match json_object(&command.payload) {
+            Ok(object) => object,
+            Err(error) => {
+                return ClientTelemetryCommandReply::failure(
+                    &command.command_id,
+                    format!("failed to parse config payload: {error}"),
+                )
+            }
+        };
+
+        let enabled = match optional_bool(&object, "enabled") {
+            Ok(value) => value,
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        let heartbeat_ms = match optional_i64(&object, "heartbeat_interval_ms") {
+            Ok(value) => value,
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        let sampling_rate = match optional_f64(&object, "sampling_rate") {
+            Ok(value) => value,
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        // ttl_seconds is ignored by clients, but a known field with a malformed type
+        // still rejects the entire typed payload just as Go's ConfigPayload decoder does.
+        if let Err(error) = optional_i64(&object, "ttl_seconds") {
+            return ClientTelemetryCommandReply::failure(&command.command_id, error);
+        }
+        if heartbeat_ms.is_some_and(|value| value <= 0) {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "heartbeat_interval_ms must be positive",
+            );
+        }
+
+        let acted_on = ["enabled", "heartbeat_interval_ms", "sampling_rate"];
+        let mut ignored: Vec<_> = object
+            .keys()
+            .filter(|key| !acted_on.contains(&key.as_str()))
+            .cloned()
+            .collect();
+        ignored.sort();
+        let mut applied = Vec::new();
+
+        // All validation above precedes this lock: updates are all-or-nothing.
+        let mut state = self.state.lock();
+        if let Some(enabled) = enabled {
+            state.config.enabled = enabled;
+            applied.push("enabled");
+        }
+        if let Some(heartbeat_ms) = heartbeat_ms {
+            state.config.heartbeat_interval = Duration::from_millis(heartbeat_ms as u64);
+            applied.push("heartbeat_interval_ms");
+        }
+        if let Some(sampling_rate) = sampling_rate {
+            state.config.sampling_rate = sampling_rate.clamp(0.0, 1.0);
+            applied.push("sampling_rate");
+        }
+        drop(state);
+
+        let payload = serde_json::to_vec(&json!({
+            "applied": applied,
+            "ignored": ignored,
+        }))
+        .unwrap_or_default();
+        ClientTelemetryCommandReply::success(&command.command_id, payload)
+    }
+
+    fn handle_collection_metrics(
+        &self,
+        command: &ClientTelemetryCommand,
+    ) -> ClientTelemetryCommandReply {
+        if command.payload.is_empty() {
+            let state = self.state.lock();
+            let payload = serde_json::to_vec(&json!({
+                "enabled_collections": state.enabled_collections.iter().collect::<Vec<_>>(),
+                "all_collections_enabled": state.all_collections_enabled,
+            }))
+            .unwrap_or_default();
+            return ClientTelemetryCommandReply::success(&command.command_id, payload);
+        }
+        let object = match json_object(&command.payload) {
+            Ok(object) => object,
+            Err(error) => {
+                return ClientTelemetryCommandReply::failure(
+                    &command.command_id,
+                    format!("failed to parse collection_metrics payload: {error}"),
+                )
+            }
+        };
+        let enabled = match optional_bool(&object, "enabled") {
+            Ok(value) => value.unwrap_or(false),
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        let collections = match optional_string_array(&object, "collections") {
+            Ok(value) => value.unwrap_or_default(),
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        if let Err(error) = optional_string_array(&object, "metrics_types") {
+            return ClientTelemetryCommandReply::failure(&command.command_id, error);
+        }
+        if enabled && collections.is_empty() {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "collections list cannot be empty when enabled=true",
+            );
+        }
+
+        let wildcard = collections.iter().any(|collection| collection == "*");
+        let mut state = self.state.lock();
+        if enabled {
+            if wildcard {
+                state.all_collections_enabled = true;
+            } else {
+                state.enabled_collections.extend(collections);
+            }
+        } else if wildcard || collections.is_empty() {
+            state.all_collections_enabled = false;
+            state.enabled_collections.clear();
+        } else {
+            for collection in collections {
+                state.enabled_collections.remove(&collection);
+            }
+        }
+        ClientTelemetryCommandReply::success(&command.command_id, Vec::new())
+    }
+
+    fn handle_show_errors(&self, command: &ClientTelemetryCommand) -> ClientTelemetryCommandReply {
+        let max_count = if command.payload.is_empty() {
+            100
+        } else {
+            let object = match json_object(&command.payload) {
+                Ok(object) => object,
+                Err(error) => {
+                    return ClientTelemetryCommandReply::failure(
+                        &command.command_id,
+                        format!("failed to parse show_errors payload: {error}"),
+                    )
+                }
+            };
+            match optional_i64(&object, "max_count") {
+                Ok(Some(value)) if value > 0 => value as usize,
+                Ok(_) => 100,
+                Err(error) => {
+                    return ClientTelemetryCommandReply::failure(&command.command_id, error)
+                }
+            }
+        };
+        let mut errors: Vec<_> = self
+            .state
+            .lock()
+            .errors
+            .iter()
+            .rev()
+            .take(max_count)
+            .cloned()
+            .collect();
+        if errors.is_empty() {
+            return ClientTelemetryCommandReply::success(&command.command_id, Vec::new());
+        }
+        let mut payload = serde_json::to_vec(&errors).unwrap_or_default();
+        while payload.len() > MAX_REPLY_PAYLOAD_SIZE && errors.len() > 1 {
+            errors.truncate(errors.len() / 2);
+            payload = serde_json::to_vec(&errors).unwrap_or_default();
+        }
+        while payload.len() > MAX_REPLY_PAYLOAD_SIZE && !errors[0].error_message.is_empty() {
+            // Halve at a UTF-8 boundary and re-encode. Basing the decision on the encoded
+            // JSON size also handles quotes/backslashes, which may expand on serialization.
+            let message = &mut errors[0].error_message;
+            let mut new_len = message.len() / 2;
+            while new_len > 0 && !message.is_char_boundary(new_len) {
+                new_len -= 1;
+            }
+            message.truncate(new_len);
+            if new_len > 0 {
+                message.push_str("...(truncated)");
+            }
+            payload = serde_json::to_vec(&errors).unwrap_or_default();
+        }
+        if payload.len() > MAX_REPLY_PAYLOAD_SIZE {
+            return ClientTelemetryCommandReply::failure(&command.command_id, "response too large");
+        }
+        ClientTelemetryCommandReply::success(&command.command_id, payload)
+    }
+
+    fn handle_show_latency_history(
+        &self,
+        command: &ClientTelemetryCommand,
+    ) -> ClientTelemetryCommandReply {
+        if command.payload.is_empty() {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "payload is required with start_time and end_time",
+            );
+        }
+        let object = match json_object(&command.payload) {
+            Ok(object) => object,
+            Err(error) => {
+                return ClientTelemetryCommandReply::failure(
+                    &command.command_id,
+                    format!("failed to parse show_latency_history payload: {error}"),
+                )
+            }
+        };
+        let start = match required_string(&object, "start_time")
+            .and_then(|value| parse_rfc3339_millis(&value, "start_time"))
+        {
+            Ok(value) => value,
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        let end = match required_string(&object, "end_time")
+            .and_then(|value| parse_rfc3339_millis(&value, "end_time"))
+        {
+            Ok(value) => value,
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        let detail = match optional_bool(&object, "detail") {
+            Ok(value) => value.unwrap_or(false),
+            Err(error) => return ClientTelemetryCommandReply::failure(&command.command_id, error),
+        };
+        if end < start {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "end_time must be after start_time",
+            );
+        }
+        if end.saturating_sub(start) > HISTORY_RETENTION.as_millis() as i64 {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "time range cannot exceed 1 hour",
+            );
+        }
+
+        let snapshots: Vec<_> = self
+            .state
+            .lock()
+            .snapshots
+            .iter()
+            .filter(|snapshot| snapshot.end_time >= start && snapshot.timestamp <= end)
+            .cloned()
+            .collect();
+        let payload_value = if detail {
+            json!({
+                "snapshots": snapshots.iter().map(snapshot_json).collect::<Vec<_>>(),
+                "total_snapshots": snapshots.len(),
+            })
+        } else {
+            aggregate_snapshot_json(&snapshots, start, end)
+        };
+        let payload = serde_json::to_vec(&payload_value).unwrap_or_default();
+        if payload.len() > MAX_REPLY_PAYLOAD_SIZE {
+            return ClientTelemetryCommandReply::failure(
+                &command.command_id,
+                "response too large, try a smaller time range",
+            );
+        }
+        ClientTelemetryCommandReply::success(&command.command_id, payload)
+    }
+
+    fn handle_get_config(&self, command: &ClientTelemetryCommand) -> ClientTelemetryCommandReply {
+        let state = self.state.lock();
+        let enabled_collections: Vec<_> = if state.all_collections_enabled {
+            vec!["*".to_owned()]
+        } else {
+            state.enabled_collections.iter().cloned().collect()
+        };
+        let payload = serde_json::to_vec(&json!({
+            "user_config": {
+                "address": self.client_config.uri,
+                "username": self.client_config.username,
+                "db_name": self.client_config.initial_database,
+                "enable_tls_auth": self.client_config.tls_enabled,
+                "retry_max_retry": self.client_config.retry_max_attempts,
+                "retry_max_backoff_ms": self.client_config.retry_max_backoff_ms,
+                "current_db": self.database.read().clone(),
+                "telemetry_enabled": state.config.enabled,
+                "telemetry_heartbeat_interval_ms": state.config.heartbeat_interval.as_millis(),
+                "telemetry_sampling_rate": state.config.sampling_rate,
+                "enabled_collections": enabled_collections,
+                "all_collections_enabled": state.all_collections_enabled,
+            }
+        }))
+        .unwrap_or_default();
+        ClientTelemetryCommandReply::success(&command.command_id, payload)
+    }
+}
+
+fn json_object(payload: &[u8]) -> Result<Map<String, Value>, String> {
+    if payload.is_empty() {
+        return Ok(Map::new());
+    }
+    match serde_json::from_slice(payload).map_err(|error| error.to_string())? {
+        Value::Object(object) => Ok(object),
+        _ => Err("command payload must be a JSON object".to_owned()),
+    }
+}
+
+fn optional_bool(object: &Map<String, Value>, key: &str) -> Result<Option<bool>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(format!("{key} must be a boolean")),
+    }
+}
+
+fn optional_i64(object: &Map<String, Value>, key: &str) -> Result<Option<i64>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(value)) => value
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| format!("{key} must be a signed 64-bit integer")),
+        Some(_) => Err(format!("{key} must be an integer")),
+    }
+}
+
+fn optional_f64(object: &Map<String, Value>, key: &str) -> Result<Option<f64>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(value)) => value
+            .as_f64()
+            .filter(|value| value.is_finite())
+            .map(Some)
+            .ok_or_else(|| format!("{key} must be finite")),
+        Some(_) => Err(format!("{key} must be a number")),
+    }
+}
+
+fn optional_string_array(
+    object: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<Vec<String>>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| format!("{key} must be an array of strings"))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(format!("{key} must be an array of strings")),
+    }
+}
+
+fn required_string(object: &Map<String, Value>, key: &str) -> Result<String, String> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| format!("payload is required with {key}"))
+}
+
+fn parse_rfc3339_millis(value: &str, name: &str) -> Result<i64, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.timestamp_millis())
+        .map_err(|error| format!("invalid {name} format, expected RFC3339: {error}"))
+}
+
+fn calculate_config_hash(commands: &[common::ClientCommand]) -> String {
+    let mut persistent: Vec<_> = commands
+        .iter()
+        .filter(|command| command.persistent)
+        .collect();
+    if persistent.is_empty() {
+        return String::new();
+    }
+    persistent.sort_by(|left, right| left.command_id.cmp(&right.command_id));
+    let mut digest = Sha256::new();
+    for command in persistent {
+        digest.update(command.command_id.as_bytes());
+        digest.update(command.command_type.as_bytes());
+        digest.update(&command.payload);
+    }
+    format!("{:x}", digest.finalize())[..16].to_owned()
+}
+
+fn snapshot_json(snapshot: &TelemetrySnapshot) -> Value {
+    let metrics: Map<String, Value> = snapshot
+        .metrics
+        .iter()
+        .map(|operation| {
+            (
+                operation.operation.clone(),
+                serde_json::to_value(&operation.global).unwrap_or(Value::Null),
+            )
+        })
+        .collect();
+    json!({
+        "timestamp": snapshot.timestamp,
+        "end_time": snapshot.end_time,
+        "metrics": metrics,
+    })
+}
+
+fn aggregate_snapshot_json(snapshots: &[TelemetrySnapshot], start: i64, end: i64) -> Value {
+    #[derive(Default)]
+    struct Aggregate {
+        request_count: i64,
+        success_count: i64,
+        error_count: i64,
+        weighted_avg: f64,
+        weighted_p99: f64,
+        max_latency: f64,
+    }
+    let mut totals: BTreeMap<String, Aggregate> = BTreeMap::new();
+    for snapshot in snapshots {
+        for operation in &snapshot.metrics {
+            let total = totals.entry(operation.operation.clone()).or_default();
+            let metrics = &operation.global;
+            total.request_count += metrics.request_count;
+            total.success_count += metrics.success_count;
+            total.error_count += metrics.error_count;
+            total.weighted_avg += metrics.avg_latency_ms * metrics.request_count as f64;
+            total.weighted_p99 += metrics.p99_latency_ms * metrics.request_count as f64;
+            total.max_latency = total.max_latency.max(metrics.max_latency_ms);
+        }
+    }
+    let metrics: Map<String, Value> = totals
+        .into_iter()
+        .map(|(operation, total)| {
+            let denominator = total.request_count as f64;
+            (
+                operation,
+                json!({
+                    "request_count": total.request_count,
+                    "success_count": total.success_count,
+                    "error_count": total.error_count,
+                    "avg_latency_ms": if total.request_count == 0 { 0.0 } else { total.weighted_avg / denominator },
+                    "p99_latency_ms": if total.request_count == 0 { 0.0 } else { total.weighted_p99 / denominator },
+                    "max_latency_ms": total.max_latency,
+                }),
+            )
+        })
+        .collect();
+    json!({
+        "aggregated": {"start_time": start, "end_time": end, "metrics": metrics},
+        "snapshot_count": snapshots.len(),
+    })
+}
+
+fn metrics_to_proto(metrics: &TelemetryMetrics) -> common::Metrics {
+    common::Metrics {
+        request_count: metrics.request_count,
+        success_count: metrics.success_count,
+        error_count: metrics.error_count,
+        avg_latency_ms: metrics.avg_latency_ms,
+        p99_latency_ms: metrics.p99_latency_ms,
+        max_latency_ms: metrics.max_latency_ms,
+    }
+}
+
+async fn heartbeat_loop(weak: Weak<TelemetryInner>) {
+    loop {
+        let Some(inner) = weak.upgrade() else {
+            return;
+        };
+        inner.create_snapshot();
+        inner.send_heartbeat().await;
+        let delay = inner.next_heartbeat_delay();
+        let shutdown = inner.shutdown.clone();
+        drop(inner);
+        tokio::select! {
+            _ = shutdown.cancelled() => return,
+            _ = tokio::time::sleep(delay) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::milvus::client_telemetry_service_server::{
+        ClientTelemetryService, ClientTelemetryServiceServer,
+    };
+    use crate::v2::client::{service_bundle, V2Interceptor};
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::net::TcpListener;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::{Endpoint, Server};
+
+    struct CapturedHeartbeat {
+        request: milvus::ClientHeartbeatRequest,
+        authorization: Option<String>,
+        database: Option<String>,
+        request_millis: Option<String>,
+    }
+
+    enum HeartbeatAction {
+        Respond(milvus::ClientHeartbeatResponse),
+        Fail(Code, &'static str),
+        BlockedResponse {
+            entered: oneshot::Sender<()>,
+            release: oneshot::Receiver<()>,
+            response: milvus::ClientHeartbeatResponse,
+        },
+    }
+
+    #[derive(Clone)]
+    struct MockTelemetryService {
+        actions: Arc<tokio::sync::Mutex<VecDeque<HeartbeatAction>>>,
+        captures: mpsc::UnboundedSender<CapturedHeartbeat>,
+    }
+
+    #[tonic::async_trait]
+    impl ClientTelemetryService for MockTelemetryService {
+        async fn client_heartbeat(
+            &self,
+            request: Request<milvus::ClientHeartbeatRequest>,
+        ) -> Result<tonic::Response<milvus::ClientHeartbeatResponse>, tonic::Status> {
+            let capture = CapturedHeartbeat {
+                authorization: metadata_value(&request, "authorization"),
+                database: metadata_value(&request, "dbname"),
+                request_millis: metadata_value(&request, "client-request-unixmsec"),
+                request: request.into_inner(),
+            };
+            self.captures
+                .send(capture)
+                .expect("heartbeat capture receiver");
+
+            let action = self
+                .actions
+                .lock()
+                .await
+                .pop_front()
+                .expect("unexpected heartbeat");
+            match action {
+                HeartbeatAction::Respond(response) => Ok(tonic::Response::new(response)),
+                HeartbeatAction::Fail(code, message) => Err(tonic::Status::new(code, message)),
+                HeartbeatAction::BlockedResponse {
+                    entered,
+                    release,
+                    response,
+                } => {
+                    entered.send(()).expect("heartbeat entered receiver");
+                    release.await.expect("heartbeat release sender");
+                    Ok(tonic::Response::new(response))
+                }
+            }
+        }
+    }
+
+    struct MockTelemetryServer {
+        uri: String,
+        captures: mpsc::UnboundedReceiver<CapturedHeartbeat>,
+        shutdown: Option<oneshot::Sender<()>>,
+        task: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+    }
+
+    impl MockTelemetryServer {
+        async fn start(actions: Vec<HeartbeatAction>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind telemetry mock");
+            let address = listener.local_addr().expect("telemetry mock address");
+            let (capture_tx, capture_rx) = mpsc::unbounded_channel();
+            let service = MockTelemetryService {
+                actions: Arc::new(tokio::sync::Mutex::new(actions.into())),
+                captures: capture_tx,
+            };
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+            let task = tokio::spawn(
+                Server::builder()
+                    .add_service(ClientTelemetryServiceServer::new(service))
+                    .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                        let _ = shutdown_rx.await;
+                    }),
+            );
+            Self {
+                uri: format!("http://{address}"),
+                captures: capture_rx,
+                shutdown: Some(shutdown_tx),
+                task,
+            }
+        }
+
+        async fn next_capture(&mut self) -> CapturedHeartbeat {
+            tokio::time::timeout(Duration::from_secs(1), self.captures.recv())
+                .await
+                .expect("timed out waiting for heartbeat")
+                .expect("heartbeat server stopped")
+        }
+    }
+
+    impl Drop for MockTelemetryServer {
+        fn drop(&mut self) {
+            if let Some(shutdown) = self.shutdown.take() {
+                let _ = shutdown.send(());
+            }
+            self.task.abort();
+        }
+    }
+
+    fn metadata_value<T>(request: &Request<T>, key: &'static str) -> Option<String> {
+        request
+            .metadata()
+            .get(key)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+    }
+
+    fn success_response(commands: Vec<common::ClientCommand>) -> milvus::ClientHeartbeatResponse {
+        milvus::ClientHeartbeatResponse {
+            status: Some(common::Status::default()),
+            commands,
+            ..Default::default()
+        }
+    }
+
+    fn command_reply(command_id: &str) -> common::CommandReply {
+        common::CommandReply {
+            command_id: command_id.to_owned(),
+            success: true,
+            ..Default::default()
+        }
+    }
+
+    fn transport_manager(
+        config: TelemetryConfig,
+        uri: &str,
+        database_name: &str,
+        token: &str,
+        generation: u64,
+    ) -> ClientTelemetry {
+        let database = Arc::new(RwLock::new(database_name.to_owned()));
+        let connect = ConnectConfig::new()
+            .uri(uri)
+            .database(database_name)
+            .token(token)
+            .telemetry(config.clone());
+        let interceptor = V2Interceptor {
+            token: connect
+                .get_token()
+                .clone()
+                .map(|value| value.parse().expect("authorization metadata")),
+            database: Arc::clone(&database),
+        };
+        let channel = Endpoint::from_shared(uri.to_owned())
+            .expect("telemetry endpoint")
+            .connect_lazy();
+        let services = Arc::new(RwLock::new(service_bundle(
+            channel,
+            interceptor,
+            generation,
+        )));
+        ClientTelemetry::new(config, services, database, &connect)
+    }
+
+    fn manager(config: TelemetryConfig) -> ClientTelemetry {
+        let database = Arc::new(RwLock::new("default".to_owned()));
+        let channel = Endpoint::from_static("http://127.0.0.1:19530").connect_lazy();
+        let interceptor = V2Interceptor {
+            token: None,
+            database: Arc::clone(&database),
+        };
+        let services = Arc::new(RwLock::new(service_bundle(channel, interceptor, 7)));
+        let connect = ConnectConfig::new().telemetry(config.clone());
+        ClientTelemetry::new(config, services, database, &connect)
+    }
+
+    fn command(command_id: &str, command_type: &str, payload: &[u8]) -> ClientTelemetryCommand {
+        ClientTelemetryCommand {
+            command_id: command_id.to_owned(),
+            command_type: command_type.to_owned(),
+            payload: payload.to_vec(),
+            create_time: 10,
+            persistent: false,
+            target_scope: "global".to_owned(),
+        }
+    }
+
+    #[test]
+    fn trace_id_validation_is_strict_but_generation_is_valid() {
+        assert!(valid_trace_id("4bf92f3577b34da6a3ce929d0e0e4736"));
+        assert!(!valid_trace_id("00000000000000000000000000000000"));
+        assert!(!valid_trace_id("4BF92F3577B34DA6A3CE929D0E0E4736"));
+        assert!(!valid_trace_id("legacy-request-id"));
+        assert!(valid_trace_id(&new_client_request_id()));
+    }
+
+    #[tokio::test]
+    async fn malformed_client_request_id_is_not_exposed_to_the_interceptor() {
+        with_client_request_id("legacy-request-id", async {
+            assert_eq!(current_client_request_id(), None);
+        })
+        .await;
+        with_client_request_id("4bf92f3577b34da6a3ce929d0e0e4736", async {
+            assert_eq!(
+                current_client_request_id().as_deref(),
+                Some("4bf92f3577b34da6a3ce929d0e0e4736")
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn client_info_omits_synthetic_default_database_and_formats_local_time() {
+        let telemetry = manager(TelemetryConfig::new());
+        let info = telemetry.inner.build_client_info();
+
+        assert!(!info.reserved.contains_key("db_name"));
+        DateTime::parse_from_rfc3339(&info.local_time).expect("readable RFC3339 local_time");
+    }
+
+    #[test]
+    fn metrics_use_recent_ring_for_p99_and_reset_atomically() {
+        let mut bucket = MetricBucket::default();
+        for latency in 0..1100 {
+            bucket.record(latency, latency % 2 == 0);
+        }
+        let metrics = bucket.take().expect("metrics");
+        assert_eq!(metrics.request_count, 1100);
+        assert_eq!(metrics.success_count, 550);
+        assert_eq!(metrics.error_count, 550);
+        assert_eq!(metrics.p99_latency_ms, 1.09);
+        assert!(bucket.take().is_none());
+    }
+
+    #[tokio::test]
+    async fn push_config_validates_atomically_and_reports_ignored_keys() {
+        let telemetry = manager(TelemetryConfig::new().enabled(true));
+        let reply = telemetry.inner.handle_command(&command(
+            "bad",
+            "push_config",
+            br#"{"enabled":false,"heartbeat_interval_ms":0}"#,
+        ));
+        assert!(!reply.success);
+        assert!(telemetry.config().enabled);
+
+        let reply = telemetry.inner.handle_command(&command(
+            "ttl",
+            "push_config",
+            br#"{"ttl_seconds":60,"future_option":true}"#,
+        ));
+        assert!(reply.success);
+        let payload: Value = serde_json::from_slice(&reply.payload).expect("reply json");
+        assert_eq!(payload["applied"], json!([]));
+        assert_eq!(payload["ignored"], json!(["future_option", "ttl_seconds"]));
+
+        let reply = telemetry.inner.handle_command(&command(
+            "bad-ttl",
+            "push_config",
+            br#"{"ttl_seconds":"60"}"#,
+        ));
+        assert!(!reply.success);
+    }
+
+    #[tokio::test]
+    async fn custom_handler_can_register_another_handler_without_deadlock() {
+        let telemetry = manager(TelemetryConfig::new());
+        let reentrant = telemetry.clone();
+        telemetry.register_command_handler("custom", move |command| {
+            reentrant.register_command_handler("registered-inside", |nested| {
+                ClientTelemetryCommandReply::success(&nested.command_id, Vec::new())
+            });
+            ClientTelemetryCommandReply::success(&command.command_id, Vec::new())
+        });
+
+        let worker_telemetry = telemetry.clone();
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let reply = worker_telemetry
+                .inner
+                .handle_command(&command("outer", "custom", &[]));
+            reply_tx.send(reply).expect("reply receiver");
+        });
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("custom handler deadlocked while registering a handler");
+        worker.join().expect("custom handler thread");
+
+        assert!(reply.success);
+        assert!(
+            telemetry
+                .inner
+                .handle_command(&command("inner", "registered-inside", &[]))
+                .success
+        );
+    }
+
+    #[tokio::test]
+    async fn show_errors_truncates_utf8_by_encoded_size_below_one_mib() {
+        let telemetry = manager(TelemetryConfig::new().error_max_count(1));
+        telemetry
+            .inner
+            .state
+            .lock()
+            .errors
+            .push_back(TelemetryErrorInfo {
+                timestamp: 1,
+                operation: "Search".to_owned(),
+                error_message: "€".repeat(400_000),
+                collection: "books".to_owned(),
+                request_id: String::new(),
+            });
+
+        let reply = telemetry
+            .inner
+            .handle_command(&command("errors", "show_errors", &[]));
+        assert!(reply.success, "{}", reply.error_message);
+        assert!(reply.payload.len() <= MAX_REPLY_PAYLOAD_SIZE);
+        let decoded: Value = serde_json::from_slice(&reply.payload).expect("valid error JSON");
+        let errors = decoded.as_array().expect("error array");
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0]["error_msg"]
+            .as_str()
+            .expect("error message")
+            .ends_with("...(truncated)"));
+    }
+
+    #[test]
+    fn config_hash_is_order_independent_and_payload_sensitive() {
+        let first = common::ClientCommand {
+            command_id: "b".to_owned(),
+            command_type: "push_config".to_owned(),
+            payload: br#"{"enabled":true}"#.to_vec(),
+            create_time: 2,
+            persistent: true,
+            target_scope: "global".to_owned(),
+        };
+        let second = common::ClientCommand {
+            command_id: "a".to_owned(),
+            command_type: "push_config".to_owned(),
+            payload: br#"{"sampling_rate":0.5}"#.to_vec(),
+            create_time: 1,
+            persistent: true,
+            target_scope: "global".to_owned(),
+        };
+        let hash = calculate_config_hash(&[first.clone(), second.clone()]);
+        assert_eq!(
+            hash,
+            calculate_config_hash(&[second.clone(), first.clone()])
+        );
+        assert_eq!(hash.len(), 16);
+        let mut changed = first;
+        changed.payload = br#"{"enabled":false}"#.to_vec();
+        assert_ne!(hash, calculate_config_hash(&[second, changed]));
+    }
+
+    #[tokio::test]
+    async fn equal_timestamp_command_remains_idempotent_across_repeated_batches() {
+        let telemetry = manager(TelemetryConfig::new());
+        let executions = Arc::new(AtomicUsize::new(0));
+        let captured = Arc::clone(&executions);
+        telemetry.register_command_handler("custom", move |command| {
+            captured.fetch_add(1, Ordering::SeqCst);
+            ClientTelemetryCommandReply::success(&command.command_id, Vec::new())
+        });
+        let command = common::ClientCommand {
+            command_id: "same-ms".to_owned(),
+            command_type: "custom".to_owned(),
+            payload: Vec::new(),
+            create_time: 42,
+            persistent: false,
+            target_scope: "global".to_owned(),
+        };
+        telemetry.inner.process_commands(vec![command.clone()]);
+        telemetry.inner.process_commands(vec![command.clone()]);
+        telemetry.inner.process_commands(vec![command]);
+        let state = telemetry.inner.state.lock();
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+        assert_eq!(state.pending_replies.len(), 3);
+        assert_eq!(state.last_command_timestamp, 42);
+        assert_eq!(state.executed_commands.get("same-ms"), Some(&42));
+    }
+
+    #[tokio::test]
+    async fn collection_metrics_are_filtered_when_disabled_before_wire_snapshot() {
+        let telemetry = manager(TelemetryConfig::new());
+        telemetry.inner.handle_command(&command(
+            "enable",
+            "collection_metrics",
+            br#"{"enabled":true,"collections":["books"]}"#,
+        ));
+        telemetry
+            .inner
+            .record_operation("Search", "books", "", Duration::from_millis(2), None);
+        telemetry.inner.create_snapshot();
+        telemetry.inner.handle_command(&command(
+            "disable",
+            "collection_metrics",
+            br#"{"enabled":false,"collections":["books"]}"#,
+        ));
+        let request = telemetry.inner.heartbeat_request();
+        assert_eq!(request.metrics.len(), 1);
+        assert!(request.metrics[0].collection_metrics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn heartbeat_uses_shared_interceptor_and_clears_only_sent_replies() {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let mut server = MockTelemetryServer::start(vec![HeartbeatAction::BlockedResponse {
+            entered: entered_tx,
+            release: release_rx,
+            response: success_response(Vec::new()),
+        }])
+        .await;
+        let telemetry = transport_manager(
+            TelemetryConfig::new().enabled(true),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+        {
+            let mut state = telemetry.inner.state.lock();
+            state.pending_replies.push_back(command_reply("sent-a"));
+            state.pending_replies.push_back(command_reply("sent-b"));
+        }
+
+        let inner = Arc::clone(&telemetry.inner);
+        let heartbeat = tokio::spawn(async move { inner.send_heartbeat().await });
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("heartbeat did not reach server")
+            .expect("heartbeat sender stopped");
+        let captured = server.next_capture().await;
+        assert_eq!(captured.authorization.as_deref(), Some("cm9vdDpNaWx2dXM="));
+        assert_eq!(captured.database.as_deref(), Some("analytics"));
+        assert!(
+            captured
+                .request_millis
+                .as_deref()
+                .expect("client-request-unixmsec")
+                .parse::<u128>()
+                .expect("millisecond metadata")
+                > 0
+        );
+        assert_eq!(
+            captured
+                .request
+                .client_info
+                .as_ref()
+                .and_then(|info| info.reserved.get("db_name"))
+                .map(String::as_str),
+            Some("analytics")
+        );
+        assert_eq!(
+            captured
+                .request
+                .command_replies
+                .iter()
+                .map(|reply| reply.command_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sent-a", "sent-b"]
+        );
+
+        telemetry
+            .inner
+            .state
+            .lock()
+            .pending_replies
+            .push_back(command_reply("queued-later"));
+        release_tx.send(()).expect("release heartbeat");
+        tokio::time::timeout(Duration::from_secs(1), heartbeat)
+            .await
+            .expect("heartbeat did not finish")
+            .expect("heartbeat task panicked");
+
+        let state = telemetry.inner.state.lock();
+        assert_eq!(state.pending_replies.len(), 1);
+        assert_eq!(state.pending_replies[0].command_id, "queued-later");
+    }
+
+    #[tokio::test]
+    async fn stale_generation_success_is_discarded_without_state_changes() {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let stale_command = common::ClientCommand {
+            command_id: "stale-command".to_owned(),
+            command_type: "custom".to_owned(),
+            create_time: 99,
+            ..Default::default()
+        };
+        let server = MockTelemetryServer::start(vec![HeartbeatAction::BlockedResponse {
+            entered: entered_tx,
+            release: release_rx,
+            response: success_response(vec![stale_command]),
+        }])
+        .await;
+        let telemetry = transport_manager(
+            TelemetryConfig::new().heartbeat_interval(Duration::from_millis(5)),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+        let executions = Arc::new(AtomicUsize::new(0));
+        let captured = Arc::clone(&executions);
+        telemetry.register_command_handler("custom", move |command| {
+            captured.fetch_add(1, Ordering::SeqCst);
+            ClientTelemetryCommandReply::success(&command.command_id, Vec::new())
+        });
+        telemetry
+            .inner
+            .state
+            .lock()
+            .pending_replies
+            .push_back(command_reply("keep-me"));
+        telemetry
+            .inner
+            .unsupported_streak
+            .store(1, Ordering::Relaxed);
+        *telemetry.inner.last_heartbeat_error.write() = Some("existing failure".to_owned());
+
+        let inner = Arc::clone(&telemetry.inner);
+        let heartbeat = tokio::spawn(async move { inner.send_heartbeat().await });
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("heartbeat did not reach server")
+            .expect("heartbeat sender stopped");
+        telemetry.inner.services.write().generation = 8;
+        release_tx.send(()).expect("release stale heartbeat");
+        tokio::time::timeout(Duration::from_secs(1), heartbeat)
+            .await
+            .expect("stale heartbeat did not finish")
+            .expect("heartbeat task panicked");
+
+        assert_eq!(executions.load(Ordering::SeqCst), 0);
+        assert!(!telemetry.is_supported());
+        assert_eq!(
+            telemetry.last_heartbeat_error().as_deref(),
+            Some("existing failure")
+        );
+        assert_eq!(
+            telemetry.inner.next_heartbeat_delay(),
+            Duration::from_millis(10)
+        );
+        let state = telemetry.inner.state.lock();
+        assert_eq!(state.pending_replies.len(), 1);
+        assert_eq!(state.pending_replies[0].command_id, "keep-me");
+        assert_eq!(state.last_command_timestamp, 0);
+        assert!(state.executed_commands.is_empty());
+    }
+
+    #[tokio::test]
+    async fn accepted_response_releases_generation_lock_before_custom_handler() {
+        let server =
+            MockTelemetryServer::start(vec![HeartbeatAction::Respond(success_response(vec![
+                common::ClientCommand {
+                    command_id: "custom-command".to_owned(),
+                    command_type: "custom".to_owned(),
+                    create_time: 1,
+                    ..Default::default()
+                },
+            ]))])
+            .await;
+        let telemetry = transport_manager(
+            TelemetryConfig::new(),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+        let services = Arc::clone(&telemetry.inner.services);
+        telemetry.register_command_handler("custom", move |command| {
+            let mut bundle = services
+                .try_write()
+                .expect("generation lock leaked into custom command handler");
+            bundle.generation = 8;
+            ClientTelemetryCommandReply::success(&command.command_id, Vec::new())
+        });
+
+        telemetry.inner.send_heartbeat().await;
+
+        assert_eq!(telemetry.inner.services.read().generation, 8);
+        assert_eq!(telemetry.inner.state.lock().last_command_timestamp, 1);
+    }
+
+    #[tokio::test]
+    async fn unimplemented_backoff_recovers_after_next_success() {
+        let server = MockTelemetryServer::start(vec![
+            HeartbeatAction::Fail(Code::Unimplemented, "telemetry disabled"),
+            HeartbeatAction::Respond(success_response(Vec::new())),
+        ])
+        .await;
+        let telemetry = transport_manager(
+            TelemetryConfig::new().heartbeat_interval(Duration::from_millis(5)),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+
+        telemetry.inner.send_heartbeat().await;
+        assert!(!telemetry.is_supported());
+        assert!(telemetry
+            .last_heartbeat_error()
+            .expect("unimplemented heartbeat error")
+            .to_lowercase()
+            .contains("unimplemented"));
+        assert_eq!(
+            telemetry.inner.next_heartbeat_delay(),
+            Duration::from_millis(10)
+        );
+
+        telemetry.inner.send_heartbeat().await;
+        assert!(telemetry.is_supported());
+        assert_eq!(telemetry.last_heartbeat_error(), None);
+        assert_eq!(
+            telemetry.inner.next_heartbeat_delay(),
+            Duration::from_millis(5)
+        );
+    }
+}

--- a/src/v2/client/telemetry.rs
+++ b/src/v2/client/telemetry.rs
@@ -643,28 +643,32 @@ impl TelemetryInner {
         let state = self.state.lock();
         let enabled_collections = &state.enabled_collections;
         let all_collections_enabled = state.all_collections_enabled;
-        let metrics = state
-            .snapshots
-            .back()
-            .map(|snapshot| {
-                snapshot
-                    .metrics
-                    .iter()
-                    .map(|operation| common::OperationMetrics {
-                        operation: operation.operation.clone(),
-                        global: Some(metrics_to_proto(&operation.global)),
-                        collection_metrics: operation
-                            .collections
-                            .iter()
-                            .filter(|(name, _)| {
-                                all_collections_enabled || enabled_collections.contains(*name)
-                            })
-                            .map(|(name, metrics)| (name.clone(), metrics_to_proto(metrics)))
-                            .collect(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let metrics = if state.config.enabled {
+            state
+                .snapshots
+                .back()
+                .map(|snapshot| {
+                    snapshot
+                        .metrics
+                        .iter()
+                        .map(|operation| common::OperationMetrics {
+                            operation: operation.operation.clone(),
+                            global: Some(metrics_to_proto(&operation.global)),
+                            collection_metrics: operation
+                                .collections
+                                .iter()
+                                .filter(|(name, _)| {
+                                    all_collections_enabled || enabled_collections.contains(*name)
+                                })
+                                .map(|(name, metrics)| (name.clone(), metrics_to_proto(metrics)))
+                                .collect(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         milvus::ClientHeartbeatRequest {
             client_info: Some(self.build_client_info()),
             report_timestamp: now_millis(),
@@ -676,9 +680,6 @@ impl TelemetryInner {
     }
 
     async fn send_heartbeat(&self) {
-        if !self.state.lock().config.enabled {
-            return;
-        }
         let request = self.heartbeat_request();
         let reply_count = request.command_replies.len();
         let (mut service, generation) = {
@@ -1721,6 +1722,132 @@ mod tests {
         let request = telemetry.inner.heartbeat_request();
         assert_eq!(request.metrics.len(), 1);
         assert!(request.metrics[0].collection_metrics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn disabled_telemetry_keeps_control_heartbeat_for_ack_and_reenable() {
+        let disable = common::ClientCommand {
+            command_id: "disable".to_owned(),
+            command_type: "push_config".to_owned(),
+            payload: br#"{"enabled":false,"heartbeat_interval_ms":50}"#.to_vec(),
+            create_time: 1,
+            persistent: true,
+            target_scope: "global".to_owned(),
+        };
+        let reenable = common::ClientCommand {
+            command_id: "reenable".to_owned(),
+            command_type: "push_config".to_owned(),
+            payload: br#"{"enabled":true}"#.to_vec(),
+            create_time: 2,
+            persistent: true,
+            target_scope: "global".to_owned(),
+        };
+        let (second_entered_tx, second_entered_rx) = oneshot::channel();
+        let (release_second_tx, release_second_rx) = oneshot::channel();
+        let mut server = MockTelemetryServer::start(vec![
+            HeartbeatAction::Respond(success_response(vec![disable])),
+            HeartbeatAction::BlockedResponse {
+                entered: second_entered_tx,
+                release: release_second_rx,
+                response: success_response(vec![reenable]),
+            },
+            HeartbeatAction::Respond(success_response(Vec::new())),
+        ])
+        .await;
+        let opted_out = transport_manager(
+            TelemetryConfig::new()
+                .enabled(false)
+                .heartbeat_interval(Duration::from_millis(5)),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            6,
+        );
+        opted_out.start();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), server.captures.recv())
+                .await
+                .is_err(),
+            "an initial enabled=false must not start the heartbeat control plane"
+        );
+        drop(opted_out);
+
+        let telemetry = transport_manager(
+            TelemetryConfig::new(),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+
+        telemetry
+            .inner
+            .record_operation("Search", "books", "", Duration::from_millis(2), None);
+        telemetry.start();
+        let initial = server.next_capture().await;
+        assert_eq!(initial.request.metrics.len(), 1);
+        for _ in 0..100 {
+            if !telemetry.config().enabled
+                && telemetry.inner.state.lock().pending_replies.len() == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(!telemetry.config().enabled);
+        let (snapshot_count, disable_hash) = {
+            let state = telemetry.inner.state.lock();
+            assert_eq!(state.pending_replies.len(), 1);
+            assert_eq!(state.pending_replies[0].command_id, "disable");
+            (state.snapshots.len(), state.config_hash.clone())
+        };
+        assert!(!disable_hash.is_empty());
+
+        telemetry
+            .inner
+            .record_operation("Search", "books", "", Duration::from_millis(3), None);
+        telemetry.inner.create_snapshot();
+        assert_eq!(telemetry.inner.state.lock().snapshots.len(), snapshot_count);
+
+        let disabled = server.next_capture().await;
+        assert!(disabled.request.metrics.is_empty());
+        assert_eq!(disabled.request.config_hash, disable_hash);
+        assert_eq!(disabled.request.command_replies.len(), 1);
+        assert_eq!(disabled.request.command_replies[0].command_id, "disable");
+        tokio::time::timeout(Duration::from_secs(1), second_entered_rx)
+            .await
+            .expect("disabled control heartbeat did not reach the server")
+            .expect("disabled control heartbeat sender stopped");
+        release_second_tx
+            .send(())
+            .expect("disabled control heartbeat stopped before re-enable");
+        for _ in 0..100 {
+            if telemetry.config().enabled && telemetry.inner.state.lock().pending_replies.len() == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(telemetry.config().enabled);
+        let reenable_hash = {
+            let state = telemetry.inner.state.lock();
+            assert_eq!(state.pending_replies[0].command_id, "reenable");
+            state.config_hash.clone()
+        };
+        assert!(!reenable_hash.is_empty());
+
+        let reenabled = server.next_capture().await;
+        assert_eq!(reenabled.request.config_hash, reenable_hash);
+        assert_eq!(reenabled.request.command_replies.len(), 1);
+        assert_eq!(reenabled.request.command_replies[0].command_id, "reenable");
+        for _ in 0..100 {
+            if telemetry.inner.state.lock().pending_replies.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(telemetry.inner.state.lock().pending_replies.is_empty());
+        telemetry.inner.shutdown.cancel();
     }
 
     #[tokio::test]

--- a/src/v2/client/telemetry.rs
+++ b/src/v2/client/telemetry.rs
@@ -40,9 +40,14 @@ const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_UNSUPPORTED_BACKOFF: Duration = Duration::from_secs(30 * 60);
 const LATENCY_SAMPLE_CAPACITY: usize = 1000;
+// Retaining all 1000 live-ring values in every one-second history window would
+// exceed 200 MiB. Preserve 128 sorted, equidistant quantiles including min/max;
+// seven operations across the 4096-window hard cap use about 28 MiB of raw i64s.
+const HISTORY_LATENCY_SAMPLE_CAPACITY: usize = 128;
 const MAX_REPLY_PAYLOAD_SIZE: usize = 1024 * 1024;
 const HISTORY_RETENTION: Duration = Duration::from_secs(60 * 60);
-const MAX_HISTORY_SNAPSHOTS: usize = 3600;
+// A one-second heartbeat produces 3601 boundary-inclusive windows in an hour.
+const MAX_HISTORY_SNAPSHOTS: usize = 4096;
 const SAMPLING_SCALE: u64 = 1_000_000_000;
 
 tokio::task_local! {
@@ -251,6 +256,23 @@ impl MetricBucket {
         *self = Self::default();
         Some(metrics)
     }
+
+    fn history_samples(&self) -> Vec<i64> {
+        let mut samples: Vec<_> = self.samples.iter().copied().collect();
+        samples.sort_unstable();
+        if samples.len() <= HISTORY_LATENCY_SAMPLE_CAPACITY {
+            return samples;
+        }
+        let denominator = HISTORY_LATENCY_SAMPLE_CAPACITY - 1;
+        (0..HISTORY_LATENCY_SAMPLE_CAPACITY)
+            .map(|index| {
+                // Integer rounding selects equidistant order statistics and includes
+                // both endpoints, retaining distribution shape rather than only a tail.
+                let numerator = index * (samples.len() - 1);
+                samples[(numerator + denominator / 2) / denominator]
+            })
+            .collect()
+    }
 }
 
 #[derive(Default)]
@@ -270,7 +292,8 @@ impl OperationCollector {
         }
     }
 
-    fn take(&mut self, operation: String) -> Option<TelemetryOperationMetrics> {
+    fn take(&mut self, operation: String) -> Option<(TelemetryOperationMetrics, Vec<i64>)> {
+        let global_samples = self.global.history_samples();
         let global = self.global.take()?;
         let mut collections = BTreeMap::new();
         for (name, bucket) in &mut self.collections {
@@ -280,12 +303,23 @@ impl OperationCollector {
         }
         self.collections
             .retain(|_, bucket| bucket.request_count != 0);
-        Some(TelemetryOperationMetrics {
-            operation,
-            global,
-            collections,
-        })
+        Some((
+            TelemetryOperationMetrics {
+                operation,
+                global,
+                collections,
+            },
+            global_samples,
+        ))
     }
+}
+
+#[derive(Clone)]
+struct StoredSnapshot {
+    snapshot: TelemetrySnapshot,
+    // Internal-only global samples. They are deliberately excluded from heartbeat,
+    // detail replies, and the public TelemetrySnapshot type.
+    global_samples: BTreeMap<String, Vec<i64>>,
 }
 
 type CommandHandler = dyn Fn(&ClientTelemetryCommand) -> ClientTelemetryCommandReply + Send + Sync;
@@ -293,7 +327,7 @@ type CommandHandler = dyn Fn(&ClientTelemetryCommand) -> ClientTelemetryCommandR
 struct RuntimeState {
     config: TelemetryConfig,
     collectors: BTreeMap<String, OperationCollector>,
-    snapshots: VecDeque<TelemetrySnapshot>,
+    snapshots: VecDeque<StoredSnapshot>,
     last_snapshot_end: i64,
     errors: VecDeque<TelemetryErrorInfo>,
     enabled_collections: BTreeSet<String>,
@@ -468,7 +502,13 @@ impl ClientTelemetry {
 
     /// Returns retained metric snapshots in chronological order.
     pub fn snapshots(&self) -> Vec<TelemetrySnapshot> {
-        self.inner.state.lock().snapshots.iter().cloned().collect()
+        self.inner
+            .state
+            .lock()
+            .snapshots
+            .iter()
+            .map(|stored| stored.snapshot.clone())
+            .collect()
     }
 
     /// Registers or replaces a custom command handler.
@@ -584,22 +624,27 @@ impl TelemetryInner {
         state.last_snapshot_end = now;
 
         let mut metrics = Vec::new();
+        let mut global_samples = BTreeMap::new();
         for (operation, collector) in &mut state.collectors {
-            if let Some(metric) = collector.take(operation.clone()) {
+            if let Some((metric, samples)) = collector.take(operation.clone()) {
+                global_samples.insert(operation.clone(), samples);
                 metrics.push(metric);
             }
         }
-        state.snapshots.push_back(TelemetrySnapshot {
-            timestamp: start,
-            end_time: now,
-            metrics,
+        state.snapshots.push_back(StoredSnapshot {
+            snapshot: TelemetrySnapshot {
+                timestamp: start,
+                end_time: now,
+                metrics,
+            },
+            global_samples,
         });
 
         let oldest = now.saturating_sub(HISTORY_RETENTION.as_millis() as i64);
         while state
             .snapshots
             .front()
-            .is_some_and(|snapshot| snapshot.end_time < oldest)
+            .is_some_and(|stored| stored.snapshot.end_time < oldest)
         {
             state.snapshots.pop_front();
         }
@@ -663,8 +708,9 @@ impl TelemetryInner {
             state
                 .snapshots
                 .back()
-                .map(|snapshot| {
-                    snapshot
+                .map(|stored| {
+                    stored
+                        .snapshot
                         .metrics
                         .iter()
                         .map(|operation| common::OperationMetrics {
@@ -1094,12 +1140,15 @@ impl TelemetryInner {
             .lock()
             .snapshots
             .iter()
-            .filter(|snapshot| snapshot.end_time >= start && snapshot.timestamp <= end)
+            .filter(|stored| stored.snapshot.end_time >= start && stored.snapshot.timestamp <= end)
             .cloned()
             .collect();
         let payload_value = if detail {
             json!({
-                "snapshots": snapshots.iter().map(snapshot_json).collect::<Vec<_>>(),
+                "snapshots": snapshots
+                    .iter()
+                    .map(|stored| snapshot_json(&stored.snapshot))
+                    .collect::<Vec<_>>(),
                 "total_snapshots": snapshots.len(),
             })
         } else {
@@ -1255,33 +1304,59 @@ fn snapshot_json(snapshot: &TelemetrySnapshot) -> Value {
     })
 }
 
-fn aggregate_snapshot_json(snapshots: &[TelemetrySnapshot], start: i64, end: i64) -> Value {
+fn aggregate_snapshot_json(snapshots: &[StoredSnapshot], start: i64, end: i64) -> Value {
     #[derive(Default)]
     struct Aggregate {
         request_count: i64,
         success_count: i64,
         error_count: i64,
         weighted_avg: f64,
-        weighted_p99: f64,
         max_latency: f64,
+        latency_samples: Vec<(f64, f64)>,
     }
     let mut totals: BTreeMap<String, Aggregate> = BTreeMap::new();
-    for snapshot in snapshots {
-        for operation in &snapshot.metrics {
+    for stored in snapshots {
+        for operation in &stored.snapshot.metrics {
             let total = totals.entry(operation.operation.clone()).or_default();
             let metrics = &operation.global;
             total.request_count += metrics.request_count;
             total.success_count += metrics.success_count;
             total.error_count += metrics.error_count;
             total.weighted_avg += metrics.avg_latency_ms * metrics.request_count as f64;
-            total.weighted_p99 += metrics.p99_latency_ms * metrics.request_count as f64;
             total.max_latency = total.max_latency.max(metrics.max_latency_ms);
+            if let Some(samples) = stored.global_samples.get(&operation.operation) {
+                if !samples.is_empty() {
+                    let weight = metrics.request_count as f64 / samples.len() as f64;
+                    total.latency_samples.extend(
+                        samples
+                            .iter()
+                            .map(|latency_us| (*latency_us as f64 / 1000.0, weight)),
+                    );
+                }
+            }
         }
     }
     let metrics: Map<String, Value> = totals
         .into_iter()
-        .map(|(operation, total)| {
+        .map(|(operation, mut total)| {
             let denominator = total.request_count as f64;
+            total
+                .latency_samples
+                .sort_by(|left, right| left.0.total_cmp(&right.0));
+            let mut p99_latency_ms = total
+                .latency_samples
+                .last()
+                .map(|sample| sample.0)
+                .unwrap_or_default();
+            let target = 0.99 * denominator;
+            let mut cumulative = 0.0;
+            for &(latency, weight) in &total.latency_samples {
+                cumulative += weight;
+                if cumulative > target {
+                    p99_latency_ms = latency;
+                    break;
+                }
+            }
             (
                 operation,
                 json!({
@@ -1289,7 +1364,7 @@ fn aggregate_snapshot_json(snapshots: &[TelemetrySnapshot], start: i64, end: i64
                     "success_count": total.success_count,
                     "error_count": total.error_count,
                     "avg_latency_ms": if total.request_count == 0 { 0.0 } else { total.weighted_avg / denominator },
-                    "p99_latency_ms": if total.request_count == 0 { 0.0 } else { total.weighted_p99 / denominator },
+                    "p99_latency_ms": p99_latency_ms,
                     "max_latency_ms": total.max_latency,
                 }),
             )
@@ -1603,6 +1678,80 @@ mod tests {
         assert_eq!(metrics.error_count, 550);
         assert_eq!(metrics.p99_latency_ms, 1.09);
         assert!(bucket.take().is_none());
+    }
+
+    #[tokio::test]
+    async fn aggregates_p99_from_bounded_cross_window_latency_samples() {
+        let telemetry = manager(TelemetryConfig::new().enabled(true));
+        {
+            let mut state = telemetry.inner.state.lock();
+            let collector = state.collectors.entry("Search".to_owned()).or_default();
+            for _ in 0..256 {
+                collector.record(None, 1_000, true);
+            }
+        }
+        telemetry.inner.create_snapshot();
+        {
+            let mut state = telemetry.inner.state.lock();
+            let collector = state.collectors.entry("Search".to_owned()).or_default();
+            for _ in 0..256 {
+                collector.record(None, 100_000, true);
+            }
+        }
+        telemetry.inner.create_snapshot();
+
+        let (start, end) = {
+            let state = telemetry.inner.state.lock();
+            assert_eq!(state.snapshots.len(), 2);
+            for stored in &state.snapshots {
+                assert_eq!(stored.global_samples["Search"].len(), 128);
+                assert!(snapshot_json(&stored.snapshot)
+                    .get("global_samples")
+                    .is_none());
+            }
+            (
+                state.snapshots.front().unwrap().snapshot.timestamp - 1,
+                state.snapshots.back().unwrap().snapshot.end_time + 1,
+            )
+        };
+        let payload = serde_json::to_vec(&json!({
+            "start_time": DateTime::<Utc>::from_timestamp_millis(start)
+                .unwrap()
+                .to_rfc3339(),
+            "end_time": DateTime::<Utc>::from_timestamp_millis(end)
+                .unwrap()
+                .to_rfc3339(),
+            "detail": false,
+        }))
+        .unwrap();
+        let reply = telemetry.inner.handle_command(&command(
+            "latency-aggregate",
+            "show_latency_history",
+            &payload,
+        ));
+        assert!(reply.success, "{}", reply.error_message);
+        let body: Value = serde_json::from_slice(&reply.payload).unwrap();
+        let search = &body["aggregated"]["metrics"]["Search"];
+
+        assert_eq!(body["snapshot_count"], 2);
+        assert_eq!(search["request_count"], 512);
+        assert_eq!(search["avg_latency_ms"], 50.5);
+        // Averaging the two window p99s would produce 50.5 ms. The combined
+        // distribution's p99 belongs to the equally sized slow window.
+        assert_eq!(search["p99_latency_ms"], 100.0);
+    }
+
+    #[tokio::test]
+    async fn history_hard_cap_covers_one_second_hour_boundaries() {
+        let telemetry = manager(TelemetryConfig::new().enabled(true));
+        for _ in 0..=MAX_HISTORY_SNAPSHOTS {
+            telemetry.inner.create_snapshot();
+        }
+        assert_eq!(
+            telemetry.inner.state.lock().snapshots.len(),
+            MAX_HISTORY_SNAPSHOTS
+        );
+        assert!(MAX_HISTORY_SNAPSHOTS >= 3601);
     }
 
     #[tokio::test]

--- a/src/v2/client/telemetry.rs
+++ b/src/v2/client/telemetry.rs
@@ -28,7 +28,8 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio_util::sync::CancellationToken;
@@ -82,6 +83,16 @@ fn valid_trace_id(value: &str) -> bool {
 
 fn current_telemetry_trace_id() -> String {
     current_client_request_id().unwrap_or_default()
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    }
 }
 
 fn now_millis() -> i64 {
@@ -356,6 +367,7 @@ struct TelemetryInner {
     command_lock: Mutex<()>,
     services: SharedServices,
     database: Arc<RwLock<String>>,
+    database_explicit: Arc<AtomicBool>,
     client_config: ClientConfigSnapshot,
     client_id: String,
     client_id_stable: bool,
@@ -381,6 +393,7 @@ impl ClientTelemetry {
         config: TelemetryConfig,
         services: SharedServices,
         database: Arc<RwLock<String>>,
+        database_explicit: Arc<AtomicBool>,
         connect: &ConnectConfig,
     ) -> Self {
         let client_id_stable = !config.client_id.is_empty();
@@ -399,6 +412,7 @@ impl ClientTelemetry {
             command_lock: Mutex::new(()),
             services,
             database,
+            database_explicit,
             client_config: ClientConfigSnapshot {
                 uri: connect.uri.clone(),
                 username,
@@ -624,9 +638,11 @@ impl TelemetryInner {
             ),
         ]);
         let database = self.database.read().clone();
-        // ClientV2 normalizes an omitted database to `default` internally. Do not turn
-        // that implementation detail into an explicit database declaration on the wire.
-        if !database.is_empty() && database != "default" {
+        // ClientV2 normalizes an omitted database to `default` internally. Track whether
+        // the caller actually selected it so omitted and explicit `default` remain distinct.
+        if !database.is_empty()
+            && (database != "default" || self.database_explicit.load(Ordering::Acquire))
+        {
             reserved.insert("db_name".to_owned(), database);
         }
         common::ClientInfo {
@@ -820,12 +836,22 @@ impl TelemetryInner {
                 // Clone under the read lock, then explicitly release it before calling
                 // user code. A custom handler may register another handler itself.
                 let handler = self.command_handlers.read().get(command_type).cloned();
-                handler.map(|handler| handler(command)).unwrap_or_else(|| {
-                    ClientTelemetryCommandReply::failure(
+                match handler {
+                    Some(handler) => match catch_unwind(AssertUnwindSafe(|| handler(command))) {
+                        Ok(reply) => reply,
+                        Err(payload) => ClientTelemetryCommandReply::failure(
+                            &command.command_id,
+                            format!(
+                                "custom command handler panicked: {}",
+                                panic_payload_message(payload.as_ref())
+                            ),
+                        ),
+                    },
+                    None => ClientTelemetryCommandReply::failure(
                         &command.command_id,
                         format!("unknown command type: {command_type}"),
-                    )
-                })
+                    ),
+                }
             }
         }
     }
@@ -1461,6 +1487,7 @@ mod tests {
         generation: u64,
     ) -> ClientTelemetry {
         let database = Arc::new(RwLock::new(database_name.to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(!database_name.is_empty()));
         let connect = ConnectConfig::new()
             .uri(uri)
             .database(database_name)
@@ -1472,6 +1499,7 @@ mod tests {
                 .clone()
                 .map(|value| value.parse().expect("authorization metadata")),
             database: Arc::clone(&database),
+            database_explicit: Arc::clone(&database_explicit),
         };
         let channel = Endpoint::from_shared(uri.to_owned())
             .expect("telemetry endpoint")
@@ -1481,19 +1509,21 @@ mod tests {
             interceptor,
             generation,
         )));
-        ClientTelemetry::new(config, services, database, &connect)
+        ClientTelemetry::new(config, services, database, database_explicit, &connect)
     }
 
     fn manager(config: TelemetryConfig) -> ClientTelemetry {
         let database = Arc::new(RwLock::new("default".to_owned()));
+        let database_explicit = Arc::new(AtomicBool::new(false));
         let channel = Endpoint::from_static("http://127.0.0.1:19530").connect_lazy();
         let interceptor = V2Interceptor {
             token: None,
             database: Arc::clone(&database),
+            database_explicit: Arc::clone(&database_explicit),
         };
         let services = Arc::new(RwLock::new(service_bundle(channel, interceptor, 7)));
         let connect = ConnectConfig::new().telemetry(config.clone());
-        ClientTelemetry::new(config, services, database, &connect)
+        ClientTelemetry::new(config, services, database, database_explicit, &connect)
     }
 
     fn command(command_id: &str, command_type: &str, payload: &[u8]) -> ClientTelemetryCommand {
@@ -1538,6 +1568,27 @@ mod tests {
 
         assert!(!info.reserved.contains_key("db_name"));
         DateTime::parse_from_rfc3339(&info.local_time).expect("readable RFC3339 local_time");
+    }
+
+    #[tokio::test]
+    async fn client_info_reports_an_explicit_default_database() {
+        let telemetry = transport_manager(
+            TelemetryConfig::new(),
+            "http://127.0.0.1:19530",
+            "default",
+            "",
+            0,
+        );
+
+        assert_eq!(
+            telemetry
+                .inner
+                .build_client_info()
+                .reserved
+                .get("db_name")
+                .map(String::as_str),
+            Some("default")
+        );
     }
 
     #[test]
@@ -1614,6 +1665,45 @@ mod tests {
                 .handle_command(&command("inner", "registered-inside", &[]))
                 .success
         );
+    }
+
+    #[tokio::test]
+    async fn panicking_custom_handler_returns_failure_and_heartbeat_continues() {
+        let panic_command = common::ClientCommand {
+            command_id: "panic-command".to_owned(),
+            command_type: "panicking".to_owned(),
+            create_time: 1,
+            ..Default::default()
+        };
+        let mut server = MockTelemetryServer::start(vec![
+            HeartbeatAction::Respond(success_response(vec![panic_command])),
+            HeartbeatAction::Respond(success_response(Vec::new())),
+        ])
+        .await;
+        let telemetry = transport_manager(
+            TelemetryConfig::new().heartbeat_interval(Duration::from_millis(5)),
+            &server.uri,
+            "analytics",
+            "root:Milvus",
+            7,
+        );
+        telemetry.register_command_handler("panicking", |_| {
+            std::panic::panic_any("diagnostic panic payload".to_owned())
+        });
+
+        telemetry.start();
+        let first = server.next_capture().await;
+        assert!(first.request.command_replies.is_empty());
+        let second = server.next_capture().await;
+        assert_eq!(second.request.command_replies.len(), 1);
+        let reply = &second.request.command_replies[0];
+        assert_eq!(reply.command_id, "panic-command");
+        assert!(!reply.success);
+        assert!(reply
+            .error_message
+            .contains("custom command handler panicked"));
+        assert!(reply.error_message.contains("diagnostic panic payload"));
+        telemetry.inner.shutdown.cancel();
     }
 
     #[tokio::test]

--- a/src/v2/client/utility.rs
+++ b/src/v2/client/utility.rs
@@ -581,10 +581,16 @@ impl ClientV2 {
         &self,
         request: request::utility::RunAnalyzerRequest,
     ) -> Result<response::utility::RunAnalyzerResponse> {
-        let database = self.current_database();
-        let response = rpc_with_retry!(self, run_analyzer, request.into_proto(&database))?;
-        status_to_result(&response.status)?;
-        Ok(response::utility::RunAnalyzerResponse::from_proto(response))
+        let telemetry = self.telemetry.begin_operation("RunAnalyzer", "");
+        let result = async {
+            let database = self.current_database();
+            let response = rpc_with_retry!(self, run_analyzer, request.into_proto(&database))?;
+            status_to_result(&response.status)?;
+            Ok(response::utility::RunAnalyzerResponse::from_proto(response))
+        }
+        .await;
+        telemetry.finish(&result);
+        result
     }
 
     /// Refreshes an external collection from its external data source.

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -53,8 +53,10 @@ pub mod utils;
 
 pub use bulk_import::*;
 pub use client::{
-    ClientV2, MilvusClientV2Session, OptimizeTask, QueryIterator, SearchIterator, SearchIteratorV1,
-    SearchIteratorV2,
+    new_client_request_id, with_client_request_id, ClientTelemetry, ClientTelemetryCommand,
+    ClientTelemetryCommandReply, ClientV2, MilvusClientV2Session, OptimizeTask, QueryIterator,
+    SearchIterator, SearchIteratorV1, SearchIteratorV2, TelemetryErrorInfo, TelemetryMetrics,
+    TelemetryOperationMetrics, TelemetrySnapshot,
 };
 pub use types::*;
 pub use utils::*;

--- a/src/v2/prelude.rs
+++ b/src/v2/prelude.rs
@@ -32,4 +32,7 @@ pub use crate::v2::response::{
     resource_group::*, snapshot::*, utility::*,
 };
 pub use crate::v2::types::*;
-pub use crate::v2::{ClientV2, MilvusClientV2Session, OptimizeTask, QueryIterator, SearchIterator};
+pub use crate::v2::{
+    new_client_request_id, with_client_request_id, ClientTelemetry, ClientV2,
+    MilvusClientV2Session, OptimizeTask, QueryIterator, SearchIterator,
+};

--- a/src/v2/types/common.rs
+++ b/src/v2/types/common.rs
@@ -2697,6 +2697,140 @@ impl RetryConfig {
 ///////////////////////////////////////////////////////////////////////////////
 // ConnectConfig
 ///////////////////////////////////////////////////////////////////////////////
+/// Client-side telemetry settings.
+///
+/// Telemetry is enabled by default. Set [`Self::enabled`] to `false` to disable
+/// heartbeat reporting and operation metrics for a connection.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct TelemetryConfig {
+    pub(crate) enabled: bool,
+    pub(crate) heartbeat_interval: Duration,
+    pub(crate) sampling_rate: f64,
+    pub(crate) error_max_count: usize,
+    pub(crate) client_id: String,
+}
+
+impl TelemetryConfig {
+    /// Creates telemetry settings initialized with the SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            enabled: true,
+            heartbeat_interval: Duration::from_secs(10),
+            sampling_rate: 1.0,
+            error_max_count: 100,
+            client_id: String::new(),
+        }
+    }
+
+    /// Enables or disables telemetry.
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Enables or disables telemetry and returns this value for further mutation.
+    pub fn set_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Sets the heartbeat interval.
+    ///
+    /// A zero interval is accepted here and resolved to the 10-second default,
+    /// matching a configuration assembled field by field in the Go SDK.
+    pub fn heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat_interval = interval;
+        self
+    }
+
+    /// Sets the heartbeat interval and returns this value for further mutation.
+    pub fn set_heartbeat_interval(&mut self, interval: Duration) -> &mut Self {
+        self.heartbeat_interval = interval;
+        self
+    }
+
+    /// Sets the operation sampling rate. Values are clamped to `0.0..=1.0`.
+    pub fn sampling_rate(mut self, rate: f64) -> Self {
+        self.sampling_rate = if rate.is_finite() {
+            rate.clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        self
+    }
+
+    /// Sets the operation sampling rate and returns this value for further mutation.
+    pub fn set_sampling_rate(&mut self, rate: f64) -> &mut Self {
+        self.sampling_rate = if rate.is_finite() {
+            rate.clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        self
+    }
+
+    /// Sets the maximum number of recent errors retained by the client.
+    ///
+    /// Zero resolves to the default of 100.
+    pub fn error_max_count(mut self, count: usize) -> Self {
+        self.error_max_count = count;
+        self
+    }
+
+    /// Sets the recent-error capacity and returns this value for further mutation.
+    pub fn set_error_max_count(&mut self, count: usize) -> &mut Self {
+        self.error_max_count = count;
+        self
+    }
+
+    /// Pins a client identifier that remains stable across process restarts.
+    ///
+    /// It must be unique per running client. An empty value asks the SDK to
+    /// generate a new process-local UUID.
+    pub fn client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.client_id = client_id.into();
+        self
+    }
+
+    /// Sets the stable client identifier and returns this value for further mutation.
+    pub fn set_client_id(&mut self, client_id: impl Into<String>) -> &mut Self {
+        self.client_id = client_id.into();
+        self
+    }
+
+    /// Returns whether telemetry is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the configured heartbeat interval.
+    pub fn get_heartbeat_interval(&self) -> Duration {
+        self.heartbeat_interval
+    }
+
+    /// Returns the effective operation sampling rate.
+    pub fn get_sampling_rate(&self) -> f64 {
+        self.sampling_rate
+    }
+
+    /// Returns the configured recent-error capacity.
+    pub fn get_error_max_count(&self) -> usize {
+        self.error_max_count
+    }
+
+    /// Returns the pinned client identifier, or an empty string when generated.
+    pub fn get_client_id(&self) -> &str {
+        &self.client_id
+    }
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Connection settings used to create a ClientV2.
 #[derive(Clone)]
 #[non_exhaustive]
@@ -2714,6 +2848,7 @@ pub struct ConnectConfig {
     pub(crate) keepalive_while_idle: bool,
     pub(crate) database: String,
     pub(crate) retry: RetryConfig,
+    pub(crate) telemetry: TelemetryConfig,
 }
 
 impl std::fmt::Debug for ConnectConfig {
@@ -2735,6 +2870,7 @@ impl std::fmt::Debug for ConnectConfig {
             .field("keepalive_while_idle", &self.keepalive_while_idle)
             .field("database", &self.database)
             .field("retry", &self.retry)
+            .field("telemetry", &self.telemetry)
             .finish()
     }
 }
@@ -2756,6 +2892,7 @@ impl ConnectConfig {
             keepalive_while_idle: true,
             database: String::new(),
             retry: RetryConfig::new(),
+            telemetry: TelemetryConfig::new(),
         }
     }
 
@@ -2995,6 +3132,23 @@ impl ConnectConfig {
     /// Returns the configured retry.
     pub fn get_retry(&self) -> &RetryConfig {
         &self.retry
+    }
+
+    /// Sets client-side telemetry configuration.
+    pub fn telemetry(mut self, telemetry: TelemetryConfig) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Updates client-side telemetry configuration.
+    pub fn set_telemetry(&mut self, telemetry: TelemetryConfig) -> &mut Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Returns client-side telemetry configuration.
+    pub fn get_telemetry(&self) -> &TelemetryConfig {
+        &self.telemetry
     }
 
     /// Performs the username password operation.
@@ -3641,6 +3795,30 @@ mod constructor_value_tests {
         assert_eq!(value.get_max_backoff().to_owned(), Duration::from_secs(2));
         assert_eq!(value.get_backoff_multiplier().to_owned(), 2.0);
         assert!(!value.get_retry_on_rate_limit());
+    }
+
+    #[test]
+    fn telemetry_config_builder_and_mutable_setters_match() {
+        let expected = TelemetryConfig::new()
+            .enabled(false)
+            .heartbeat_interval(Duration::from_secs(3))
+            .sampling_rate(0.25)
+            .error_max_count(12)
+            .client_id("worker-1");
+        let mut actual = TelemetryConfig::new();
+        actual
+            .set_enabled(false)
+            .set_heartbeat_interval(Duration::from_secs(3))
+            .set_sampling_rate(0.25)
+            .set_error_max_count(12)
+            .set_client_id("worker-1");
+
+        assert_eq!(actual, expected);
+        assert!(!actual.is_enabled());
+        assert_eq!(actual.get_heartbeat_interval(), Duration::from_secs(3));
+        assert_eq!(actual.get_sampling_rate(), 0.25);
+        assert_eq!(actual.get_error_max_count(), 12);
+        assert_eq!(actual.get_client_id(), "worker-1");
     }
 
     #[test]

--- a/src/v2/types/common.rs
+++ b/src/v2/types/common.rs
@@ -2742,8 +2742,9 @@ impl TelemetryConfig {
 
     /// Sets the heartbeat interval.
     ///
-    /// A zero interval is accepted here and resolved to the 10-second default,
-    /// matching a configuration assembled field by field in the Go SDK.
+    /// A zero interval is stored as configured, so [`Self::get_heartbeat_interval`]
+    /// returns [`Duration::ZERO`]. It is normalized to the 10-second default only when
+    /// a client constructs its telemetry runtime, matching the Go SDK.
     pub fn heartbeat_interval(mut self, interval: Duration) -> Self {
         self.heartbeat_interval = interval;
         self
@@ -2777,7 +2778,9 @@ impl TelemetryConfig {
 
     /// Sets the maximum number of recent errors retained by the client.
     ///
-    /// Zero resolves to the default of 100.
+    /// Zero is stored as configured, so [`Self::get_error_max_count`] returns `0`.
+    /// It is normalized to the default of 100 only when a client constructs its
+    /// telemetry runtime.
     pub fn error_max_count(mut self, count: usize) -> Self {
         self.error_max_count = count;
         self
@@ -2809,7 +2812,10 @@ impl TelemetryConfig {
         self.enabled
     }
 
-    /// Returns the configured heartbeat interval.
+    /// Returns the raw configured heartbeat interval.
+    ///
+    /// A zero value remains observable here and is normalized only when a client
+    /// constructs its telemetry runtime.
     pub fn get_heartbeat_interval(&self) -> Duration {
         self.heartbeat_interval
     }
@@ -2819,7 +2825,10 @@ impl TelemetryConfig {
         self.sampling_rate
     }
 
-    /// Returns the configured recent-error capacity.
+    /// Returns the raw configured recent-error capacity.
+    ///
+    /// A zero value remains observable here and is normalized only when a client
+    /// constructs its telemetry runtime.
     pub fn get_error_max_count(&self) -> usize {
         self.error_max_count
     }
@@ -3824,6 +3833,12 @@ mod constructor_value_tests {
         assert_eq!(actual.get_sampling_rate(), 0.25);
         assert_eq!(actual.get_error_max_count(), 12);
         assert_eq!(actual.get_client_id(), "worker-1");
+
+        let raw_zeroes = TelemetryConfig::new()
+            .heartbeat_interval(Duration::ZERO)
+            .error_max_count(0);
+        assert_eq!(raw_zeroes.get_heartbeat_interval(), Duration::ZERO);
+        assert_eq!(raw_zeroes.get_error_max_count(), 0);
     }
 
     #[test]

--- a/src/v2/types/common.rs
+++ b/src/v2/types/common.rs
@@ -2699,8 +2699,10 @@ impl RetryConfig {
 ///////////////////////////////////////////////////////////////////////////////
 /// Client-side telemetry settings.
 ///
-/// Telemetry is enabled by default. Set [`Self::enabled`] to `false` to disable
-/// heartbeat reporting and operation metrics for a connection.
+/// Telemetry is enabled by default. An initial [`Self::enabled`] value of `false`
+/// prevents the heartbeat task from starting. If an already-running client is disabled
+/// by a server command, operation collection and metric payloads stop while its lightweight
+/// command heartbeat continues to deliver acknowledgements and receive a later re-enable.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct TelemetryConfig {
@@ -2723,7 +2725,10 @@ impl TelemetryConfig {
         }
     }
 
-    /// Enables or disables telemetry.
+    /// Enables or disables telemetry at connection startup.
+    ///
+    /// A server command that disables an already-running client keeps only its command
+    /// heartbeat active so acknowledgements and a later re-enable can flow.
     pub fn enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
         self

--- a/tests/v2/ut/common.rs
+++ b/tests/v2/ut/common.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use milvus::proto::{common, milvus as pb, schema};
-use milvus::v2::{ClientV2, ConnectConfig};
+use milvus::v2::{ClientV2, ConnectConfig, TelemetryConfig};
 use pb::milvus_service_server::{MilvusService, MilvusServiceServer};
 use prost::Message;
 use std::collections::{HashMap, HashSet};
@@ -43,6 +43,7 @@ fn database_name(value: String) -> String {
 struct MockState {
     calls: HashMap<&'static str, usize>,
     requests: HashMap<&'static str, Vec<String>>,
+    client_request_ids: HashMap<&'static str, Vec<Option<String>>>,
     transport_failures: HashMap<&'static str, Vec<tonic::Code>>,
     aliases: HashMap<(String, String), String>,
     databases: HashMap<String, HashMap<String, String>>,
@@ -65,6 +66,7 @@ impl Default for MockState {
         Self {
             calls: HashMap::new(),
             requests: HashMap::new(),
+            client_request_ids: HashMap::new(),
             transport_failures: HashMap::new(),
             aliases: HashMap::new(),
             databases: HashMap::new(),
@@ -104,6 +106,21 @@ pub struct MockMilvus {
 }
 
 impl MockMilvus {
+    fn record_metadata<T>(&self, method: &'static str, request: &Request<T>) {
+        let request_id = request
+            .metadata()
+            .get("client_request_id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        self.state
+            .lock()
+            .unwrap()
+            .client_request_ids
+            .entry(method)
+            .or_default()
+            .push(request_id);
+    }
+
     fn record_request<T: Debug>(&self, method: &'static str, request: &T) {
         let mut state = self.state.lock().unwrap();
         *state.calls.entry(method).or_default() += 1;
@@ -140,6 +157,16 @@ impl MockMilvus {
             .lock()
             .unwrap()
             .requests
+            .get(method)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn client_request_ids(&self, method: &'static str) -> Vec<Option<String>> {
+        self.state
+            .lock()
+            .unwrap()
+            .client_request_ids
             .get(method)
             .cloned()
             .unwrap_or_default()
@@ -224,6 +251,7 @@ macro_rules! status_method {
             Self: 'async_trait,
         {
             Box::pin(async move {
+                self.record_metadata(stringify!($name), &request);
                 let request = request.into_inner();
                 self.record_request(stringify!($name), &request);
                 if let Some(status) = self.take_transport_failure(stringify!($name)) {
@@ -246,6 +274,7 @@ macro_rules! response_method {
             Self: 'async_trait,
         {
             Box::pin(async move {
+                self.record_metadata(stringify!($name), &request);
                 let request = request.into_inner();
                 self.record_request(stringify!($name), &request);
                 if let Some(status) = self.take_transport_failure(stringify!($name)) {
@@ -272,6 +301,7 @@ macro_rules! status_method_with {
             Self: 'async_trait,
         {
             Box::pin(async move {
+                self.record_metadata(stringify!($name), &request);
                 let $request = request.into_inner();
                 self.record_request(stringify!($name), &$request);
                 let $service = self;
@@ -300,8 +330,12 @@ macro_rules! response_method_with {
             Self: 'async_trait,
         {
             Box::pin(async move {
+                self.record_metadata(stringify!($name), &request);
                 let $request = request.into_inner();
                 self.record_request(stringify!($name), &$request);
+                if let Some(status) = self.take_transport_failure(stringify!($name)) {
+                    return Err(status);
+                }
                 let $service = self;
                 let response = $body;
                 Ok(Response::new(response))
@@ -2468,6 +2502,10 @@ pub struct MockServer {
 
 impl MockServer {
     pub async fn start() -> Self {
+        Self::start_with_telemetry(TelemetryConfig::new()).await
+    }
+
+    pub async fn start_with_telemetry(telemetry: TelemetryConfig) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let incoming = TcpListenerStream::new(listener);
@@ -2484,7 +2522,10 @@ impl MockServer {
                 .unwrap();
         });
         let uri = format!("http://{address}");
-        let config = ConnectConfig::new().uri(&uri).database("default");
+        let config = ConnectConfig::new()
+            .uri(&uri)
+            .database("default")
+            .telemetry(telemetry);
         let client = ClientV2::new(&config).await.unwrap();
         Self {
             client,
@@ -2621,4 +2662,48 @@ impl MockServer {
             topology_task.await.unwrap();
         }
     }
+}
+
+#[derive(Debug)]
+pub struct OperationTotals {
+    pub request_count: i64,
+    pub success_count: i64,
+    pub error_count: i64,
+    pub max_latency_ms: f64,
+}
+
+pub async fn wait_for_operation_totals(
+    client: &ClientV2,
+    operation: &str,
+    expected_requests: i64,
+) -> OperationTotals {
+    for _ in 0..200 {
+        let totals = client.telemetry().snapshots().iter().fold(
+            OperationTotals {
+                request_count: 0,
+                success_count: 0,
+                error_count: 0,
+                max_latency_ms: 0.0,
+            },
+            |mut totals, snapshot| {
+                for metrics in snapshot
+                    .metrics
+                    .iter()
+                    .filter(|metrics| metrics.operation == operation)
+                {
+                    totals.request_count += metrics.global.request_count;
+                    totals.success_count += metrics.global.success_count;
+                    totals.error_count += metrics.global.error_count;
+                    totals.max_latency_ms =
+                        totals.max_latency_ms.max(metrics.global.max_latency_ms);
+                }
+                totals
+            },
+        );
+        if totals.request_count >= expected_requests {
+            return totals;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("timed out waiting for {expected_requests} {operation} telemetry records");
 }

--- a/tests/v2/ut/dml.rs
+++ b/tests/v2/ut/dml.rs
@@ -14,8 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::common::MockServer;
+use super::common::{wait_for_operation_totals, MockServer};
 use milvus::v2::prelude::*;
+use std::time::Duration;
+use tonic::Code;
 
 fn insert_request() -> InsertRequest {
     InsertRequest::builder()
@@ -47,6 +49,87 @@ fn zero_row_column_request() -> InsertRequest {
         }])
         .build()
         .expect("a non-empty column vector passes request-shape validation")
+}
+
+fn upsert_request(insert: InsertRequest) -> UpsertRequest {
+    UpsertRequest::builder()
+        .insert(insert)
+        .build()
+        .expect("valid upsert request")
+}
+
+fn delete_request() -> DeleteRequest {
+    DeleteRequest::builder()
+        .collection_name("books")
+        .ids(Ids::Int64(vec![1]))
+        .build()
+        .expect("valid delete request")
+}
+
+#[tokio::test]
+async fn dml_telemetry_records_each_logical_result_once() {
+    let server = MockServer::start_with_telemetry(
+        TelemetryConfig::new().heartbeat_interval(Duration::from_millis(5)),
+    )
+    .await;
+
+    server
+        .client
+        .insert(insert_request())
+        .await
+        .expect("mock insert succeeds");
+    server
+        .client
+        .insert(zero_row_column_request())
+        .await
+        .expect_err("zero-row insert fails local validation");
+
+    server
+        .client
+        .upsert(upsert_request(insert_request()))
+        .await
+        .expect("mock upsert succeeds");
+    server
+        .client
+        .upsert(upsert_request(zero_row_column_request()))
+        .await
+        .expect_err("zero-row upsert fails local validation");
+
+    server
+        .client
+        .delete(delete_request())
+        .await
+        .expect("mock delete succeeds");
+    server
+        .service
+        .fail_next_transport("delete", Code::InvalidArgument);
+    server
+        .client
+        .delete(delete_request())
+        .await
+        .expect_err("non-retriable mock delete failure reaches the caller");
+
+    for operation in ["Insert", "Upsert", "Delete"] {
+        let totals = wait_for_operation_totals(&server.client, operation, 2).await;
+        assert_eq!(totals.request_count, 2, "{operation}");
+        assert_eq!(totals.success_count, 1, "{operation}");
+        assert_eq!(totals.error_count, 1, "{operation}");
+        assert!(totals.max_latency_ms > 0.0, "{operation}");
+    }
+    assert_eq!(server.service.call_count("insert"), 1);
+    assert_eq!(server.service.call_count("upsert"), 1);
+    assert_eq!(server.service.call_count("delete"), 2);
+
+    let errors = server.client.telemetry().recent_errors(10);
+    for operation in ["Insert", "Upsert", "Delete"] {
+        let matching: Vec<_> = errors
+            .iter()
+            .filter(|error| error.operation == operation)
+            .collect();
+        assert_eq!(matching.len(), 1, "{operation}");
+        assert_eq!(matching[0].collection, "books");
+    }
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/tests/v2/ut/dql.rs
+++ b/tests/v2/ut/dql.rs
@@ -14,9 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::common::MockServer;
+use super::common::{wait_for_operation_totals, MockServer};
 use milvus::v2::prelude::*;
 use milvus::v2::response::dql::{QueryResponse, SearchResponse};
+use std::time::Duration;
+use tonic::Code;
 
 fn search_request() -> SearchRequest {
     SearchRequest::builder()
@@ -27,6 +29,145 @@ fn search_request() -> SearchRequest {
         .limit(5)
         .build()
         .expect("valid request")
+}
+
+fn telemetry_query_request() -> QueryRequest {
+    QueryRequest::builder()
+        .collection_name("books")
+        .filter("id > 0")
+        .build()
+        .expect("valid query request")
+}
+
+fn telemetry_get_request() -> GetRequest {
+    GetRequest::builder()
+        .collection_name("books")
+        .ids(Ids::Int64(vec![1]))
+        .build()
+        .expect("valid get request")
+}
+
+fn telemetry_hybrid_search_request() -> HybridSearchRequest {
+    HybridSearchRequest::builder()
+        .collection_name("books")
+        .sub_requests(vec![SubSearchRequest::builder()
+            .vector_field("vector")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .metric_type(MetricType::Cosine)
+            .limit(5)
+            .build()
+            .expect("valid sub-search request")])
+        .rerank(
+            Function::new()
+                .name("rrf")
+                .function_type(FunctionType::Rerank),
+        )
+        .limit(5)
+        .build()
+        .expect("valid hybrid-search request")
+}
+
+#[tokio::test]
+async fn dql_telemetry_records_each_logical_result_once() {
+    let server = MockServer::start_with_telemetry(
+        TelemetryConfig::new().heartbeat_interval(Duration::from_millis(5)),
+    )
+    .await;
+
+    server
+        .client
+        .query(telemetry_query_request())
+        .await
+        .expect("mock query succeeds");
+    server
+        .service
+        .fail_next_transport("query", Code::InvalidArgument);
+    server
+        .client
+        .query(telemetry_query_request())
+        .await
+        .expect_err("non-retriable mock query failure reaches the caller");
+
+    server
+        .client
+        .get(telemetry_get_request())
+        .await
+        .expect("mock get succeeds");
+    server
+        .service
+        .fail_next_transport("query", Code::InvalidArgument);
+    server
+        .client
+        .get(telemetry_get_request())
+        .await
+        .expect_err("non-retriable mock get failure reaches the caller");
+
+    server
+        .client
+        .search(search_request())
+        .await
+        .expect("mock search succeeds");
+    server
+        .service
+        .fail_next_transport("search", Code::InvalidArgument);
+    server
+        .client
+        .search(search_request())
+        .await
+        .expect_err("non-retriable mock search failure reaches the caller");
+
+    server
+        .client
+        .hybrid_search(telemetry_hybrid_search_request())
+        .await
+        .expect("mock hybrid search succeeds");
+    server
+        .service
+        .fail_next_transport("hybrid_search", Code::InvalidArgument);
+    server
+        .client
+        .hybrid_search(telemetry_hybrid_search_request())
+        .await
+        .expect_err("non-retriable mock hybrid-search failure reaches the caller");
+
+    for (operation, expected_requests, expected_successes, expected_errors) in [
+        ("Query", 4, 2, 2),
+        ("Search", 2, 1, 1),
+        ("HybridSearch", 2, 1, 1),
+    ] {
+        let totals = wait_for_operation_totals(&server.client, operation, expected_requests).await;
+        assert_eq!(totals.request_count, expected_requests, "{operation}");
+        assert_eq!(totals.success_count, expected_successes, "{operation}");
+        assert_eq!(totals.error_count, expected_errors, "{operation}");
+        assert!(totals.max_latency_ms > 0.0, "{operation}");
+    }
+    assert_eq!(server.service.call_count("query"), 4);
+    assert_eq!(server.service.call_count("search"), 2);
+    assert_eq!(server.service.call_count("hybrid_search"), 2);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn client_request_id_reaches_query_wire_only_when_valid() {
+    const VALID: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
+    let server = MockServer::start_with_telemetry(TelemetryConfig::new().enabled(false)).await;
+
+    for request_id in [
+        VALID,
+        "legacy-request-id",
+        "00000000000000000000000000000000",
+        "",
+    ] {
+        with_client_request_id(request_id, server.client.query(telemetry_query_request()))
+            .await
+            .expect("mock query succeeds");
+    }
+
+    assert_eq!(
+        server.service.client_request_ids("query"),
+        vec![Some(VALID.to_owned()), None, None, None]
+    );
+    server.shutdown().await;
 }
 
 #[test]


### PR DESCRIPTION
Related issue: milvus-io/milvus#47281

## Summary

- add default-on client telemetry to `ClientV2`, shared by client clones and cluster-scoped sessions
- report the seven Go SDK operation families once per logical call: Search, Query (including Get), HybridSearch, RunAnalyzer, Insert, Delete, and Upsert
- send immediate best-effort heartbeats and implement the five server commands: `push_config`, `collection_metrics`, `show_errors`, `show_latency_history`, and `get_config`
- keep Milvus and telemetry stubs in one generation-fenced service bundle so global-cluster failover switches them atomically
- keep the command heartbeat alive after a server-side dynamic disable so its ACK and a later re-enable can flow, while an initial user opt-out starts no task
- expose telemetry configuration, diagnostics, and opt-in OpenTelemetry-compatible client request IDs

The Rust repository's current feature surface is V2-only, so this integrates with `ClientV2` rather than extending the legacy V1 client.

## Protocol alignment

- 10-second default interval, dynamic interval updates, no per-heartbeat retry, 10-second RPC timeout, and capped UNIMPLEMENTED backoff
- deterministic sampling, recent-error and one-hour latency history, 1 MiB reply limits, persistent config hash, and equal-timestamp command deduplication
- stable per-client identity across clones/reconnects, optional caller-pinned IDs across process restarts, secret-free config reporting, and dynamic database reporting
- reply clearing and command execution are fenced against stale global-cluster generations

## Design

- https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260131-client_side_telemetry.md
- Go conformance follow-up: https://github.com/milvus-io/milvus/pull/52804

## Verification

- non-server tests: 908 passed, 0 failed, 1 ignored
- `cargo fmt --all -- --check`
- correctness/suspicious clippy gate
- V2 API checker: 115 requests and 50 responses
- rustdoc warnings gate and cargo package verification
