### PR TITLE
Support function chains and search aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,10 @@ name = "v2_filter_template"
 path = "examples/v2/filter_template.rs"
 
 [[example]]
+name = "v2_function_chain"
+path = "examples/v2/function_chain.rs"
+
+[[example]]
 name = "v2_full_text_match"
 path = "examples/v2/full_text_match.rs"
 

--- a/examples/v2/function_chain.rs
+++ b/examples/v2/function_chain.rs
@@ -1,0 +1,233 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod utils;
+
+use milvus::v2 as sdk;
+use milvus::v2::error::Result;
+use milvus::v2::prelude::*;
+use serde_json::json;
+use utils::*;
+
+const COLLECTION: &str = "RUST_V2_FUNCTION_CHAIN";
+const VECTOR: &str = "vector";
+const YEAR: &str = "year";
+const CATEGORY: &str = "category";
+const DIMENSION: usize = 128;
+
+/// Builds a rerank function chain: score recency with a decay function, blend the
+/// decayed score with the vector score, round it, sort by it, and keep the top 10.
+fn rerank_chain() -> FunctionChain {
+    FunctionChain::new()
+        .stage(FunctionChainStage::L2Rerank)
+        .name("fresh_popular_rerank")
+        .map(
+            "freshness",
+            fn_::decay(col(YEAR), "exp", 1980.0, 50.0, None, None),
+        )
+        .map(
+            "$score",
+            fn_::num_combine(
+                vec![col("$score"), col("freshness")],
+                "weighted",
+                Some(vec![0.7, 0.3]),
+            ),
+        )
+        .map("$score", fn_::round_decimal(col("$score"), 4))
+        .sort("$score", true, Some("id".to_owned()))
+        .limit(10, 0)
+}
+
+fn print_bucket(bucket: &AggregationBucket, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let key = bucket
+        .get_key()
+        .iter()
+        .map(|entry| format!("{}={:?}", entry.get_field_name(), entry.get_value()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("{indent}{{key: [{key}] count: {}", bucket.get_count());
+    for (alias, value) in bucket.get_metrics() {
+        println!("{indent}  metric {alias} = {value:?}");
+    }
+    for hit in bucket.get_hits() {
+        println!(
+            "{indent}  hit pk={:?} score={} fields={:?}",
+            hit.get_pk(),
+            hit.get_score(),
+            hit.get_fields()
+        );
+    }
+    println!("{indent}}}");
+    for sub in bucket.get_sub_groups() {
+        print_bucket(sub, depth + 1);
+    }
+}
+
+fn print_buckets(buckets: &[Vec<AggregationBucket>]) {
+    for (query_index, groups) in buckets.iter().enumerate() {
+        println!("Aggregation buckets for query vector {query_index}:");
+        for bucket in groups {
+            print_bucket(bucket, 1);
+        }
+    }
+}
+
+async fn search_with_chain(client: &sdk::ClientV2) -> Result<()> {
+    println!("==================== Search with function chain ====================");
+    let request = SearchRequest::builder()
+        .collection_name(COLLECTION)
+        .vector_field(VECTOR)
+        .vectors(SearchVectors::Float(vec![vec![1.0; DIMENSION]]))
+        .output_fields(["id", YEAR, CATEGORY])
+        .limit(10)
+        .consistency_level(sdk::ConsistencyLevel::Bounded)
+        .function_chains([rerank_chain()])
+        .build()?;
+    let response = client.search(request).await?;
+    print_search_results(response.results())?;
+    Ok(())
+}
+
+async fn search_with_aggregation(client: &sdk::ClientV2) -> Result<()> {
+    println!("==================== Search with aggregation ====================");
+    let aggregation = SearchAggregation::new()
+        .fields([CATEGORY])
+        .size(5)
+        .add_metric(
+            "avg_year",
+            MetricSpec::new().op(MetricOp::Avg).field_name(YEAR),
+        )
+        .add_metric(
+            "count",
+            MetricSpec::new().op(MetricOp::Count).field_name("*"),
+        )
+        .add_order(
+            OrderSpec::new()
+                .key("avg_year")
+                .direction(SortDirection::Desc),
+        )
+        .top_hits(
+            TopHitsSpec::new().size(3).sort([SortSpec::new()
+                .field_name(YEAR)
+                .direction(SortDirection::Desc)]),
+        );
+    let request = SearchRequest::builder()
+        .collection_name(COLLECTION)
+        .vector_field(VECTOR)
+        .vectors(SearchVectors::Float(vec![vec![1.0; DIMENSION]]))
+        .output_fields(["id", YEAR, CATEGORY])
+        .limit(10)
+        .consistency_level(sdk::ConsistencyLevel::Bounded)
+        .search_aggregation(aggregation)
+        .build()?;
+    let response = client.search(request).await?;
+    print_buckets(response.results().get_agg_buckets());
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = client().await?;
+    let schema = sdk::CollectionSchema::new()
+        .add_field(
+            sdk::FieldSchema::new()
+                .name("id")
+                .data_type(sdk::DataType::Int64)
+                .primary_key(true),
+        )
+        .add_field(
+            sdk::FieldSchema::new()
+                .name(VECTOR)
+                .data_type(sdk::DataType::FloatVector)
+                .dimension(DIMENSION as u32),
+        )
+        .add_field(
+            sdk::FieldSchema::new()
+                .name(YEAR)
+                .data_type(sdk::DataType::Int32),
+        )
+        .add_field(
+            sdk::FieldSchema::new()
+                .name(CATEGORY)
+                .data_type(sdk::DataType::VarChar)
+                .max_length(32),
+        );
+    drop_collection(&client, COLLECTION).await;
+    client
+        .create_collection(
+            sdk::request::collection::CreateCollectionRequest::builder()
+                .collection_name(COLLECTION)
+                .schema(schema)
+                .build()?,
+        )
+        .await?;
+    client
+        .create_index(
+            sdk::request::index::CreateIndexRequest::builder()
+                .collection_name(COLLECTION)
+                .index_param(
+                    sdk::IndexParam::new()
+                        .field_name(VECTOR)
+                        .index_type(sdk::IndexType::Flat)
+                        .metric_type(sdk::MetricType::Cosine),
+                )
+                .build()?,
+        )
+        .await?;
+    client
+        .load_collection(
+            sdk::request::collection::LoadCollectionRequest::builder()
+                .collection_name(COLLECTION)
+                .build()?,
+        )
+        .await?;
+    let categories = ["electronics", "books", "clothing", "sports"];
+    let rows: Vec<_> = (0..1000)
+        .map(|id| {
+            json!({
+                "id": id,
+                YEAR: id % 125 + 1900,
+                CATEGORY: categories[id % categories.len()],
+                VECTOR: float_vector(DIMENSION),
+            })
+        })
+        .collect();
+    let insert = client
+        .insert(
+            sdk::request::dml::InsertRequest::builder()
+                .collection_name(COLLECTION)
+                .rows(rows)
+                .build()?,
+        )
+        .await?;
+    println!("{} rows inserted", insert.insert_count());
+    let count = client
+        .query(
+            QueryRequest::builder()
+                .collection_name(COLLECTION)
+                .output_fields(["count(*)"])
+                .consistency_level(sdk::ConsistencyLevel::Strong)
+                .build()?,
+        )
+        .await?;
+    println!("count(*) = {}", query_count(count.results())?);
+
+    search_with_chain(&client).await?;
+    search_with_aggregation(&client).await?;
+    drop_collection(&client, COLLECTION).await;
+    Ok(())
+}

--- a/src/v2/client/iterator.rs
+++ b/src/v2/client/iterator.rs
@@ -1043,6 +1043,18 @@ fn validate_search_iterator_input(
             ));
         }
     }
+    if !search.function_chains.is_empty() {
+        return Err(Error::validation(
+            "function_chains".into(),
+            "search iterator does not support function chains".into(),
+        ));
+    }
+    if search.search_aggregation.is_some() {
+        return Err(Error::validation(
+            "search_aggregation".into(),
+            "search iterator does not support search aggregation".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -1435,6 +1447,7 @@ mod search_iterator_v2_tests {
     };
     use crate::proto::{common, milvus, schema};
     use crate::v2::request::dql::{SearchRequest, SearchVectors};
+    use crate::v2::types::FunctionChain;
     use crate::v2::MetricType;
 
     #[test]
@@ -1568,5 +1581,28 @@ mod search_iterator_v2_tests {
             MetricType::L2
         )
         .is_ok());
+    }
+
+    #[test]
+    fn v2_input_rejects_function_chains_and_search_aggregation() {
+        let mut request = SearchRequest::builder()
+            .collection_name("books")
+            .vectors(SearchVectors::Float(vec![vec![0.0]]))
+            .build()
+            .expect("valid request");
+        assert!(validate_search_iterator_input(&request, 100).is_ok());
+
+        request
+            .function_chains
+            .push(FunctionChain::new().stage(crate::v2::types::FunctionChainStage::L2Rerank));
+        assert!(validate_search_iterator_input(&request, 100).is_err());
+        request.function_chains.clear();
+
+        request.search_aggregation = Some(
+            crate::v2::types::SearchAggregation::new()
+                .fields(["category"])
+                .size(10),
+        );
+        assert!(validate_search_iterator_input(&request, 100).is_err());
     }
 }

--- a/src/v2/request/dql.rs
+++ b/src/v2/request/dql.rs
@@ -29,8 +29,8 @@ use crate::v2::request::validation::{
 };
 pub use crate::v2::types::Ids;
 use crate::v2::types::{
-    encode_sparse_vector, validate_sparse_vector, ConsistencyLevel, Function, FunctionScore,
-    MetricType,
+    encode_sparse_vector, validate_sparse_vector, ConsistencyLevel, Function, FunctionChain,
+    FunctionScore, MetricType, SearchAggregation,
 };
 pub use crate::v2::types::{
     EmbeddingList, HighlightQuery, HighlightType, Highlighter, LexicalHighlighter, SearchVectors,
@@ -514,6 +514,8 @@ pub struct SearchRequest {
     pub(crate) timezone: String,
     pub(crate) highlighter: Option<Highlighter>,
     pub(crate) consistency_level: Option<ConsistencyLevel>,
+    pub(crate) function_chains: Vec<FunctionChain>,
+    pub(crate) search_aggregation: Option<SearchAggregation>,
 }
 
 impl SearchRequest {
@@ -647,6 +649,16 @@ impl SearchRequest {
     /// Returns the consistency level.
     pub fn consistency_level(&self) -> Option<ConsistencyLevel> {
         self.consistency_level
+    }
+
+    /// Returns the function chains.
+    pub fn function_chains(&self) -> &[FunctionChain] {
+        &self.function_chains
+    }
+
+    /// Returns the search aggregation.
+    pub fn search_aggregation(&self) -> &Option<SearchAggregation> {
+        &self.search_aggregation
     }
 
     #[allow(deprecated)]
@@ -896,6 +908,15 @@ impl SearchRequest {
             namespace: None,
             highlighter: self.highlighter.map(Highlighter::into_proto),
             search_input: Some(search_input),
+            search_aggregation: self
+                .search_aggregation
+                .map(|aggregation| aggregation.into_proto())
+                .transpose()?,
+            function_chains: self
+                .function_chains
+                .into_iter()
+                .map(FunctionChain::into_proto)
+                .collect(),
             ..Default::default()
         })
     }
@@ -928,6 +949,8 @@ impl SearchRequest {
             timezone: String::new(),
             highlighter: None,
             consistency_level: None,
+            function_chains: Vec::new(),
+            search_aggregation: None,
         }
     }
 }
@@ -1085,6 +1108,30 @@ impl SearchRequestBuilder {
     /// Sets the consistency level and returns the updated value.
     pub fn consistency_level(mut self, value: ConsistencyLevel) -> Self {
         self.value.consistency_level = Some(value);
+        self
+    }
+
+    /// Sets the function chains and returns the updated value.
+    ///
+    /// Mutually exclusive with [`Self::rerank`]; Milvus rejects a search carrying both.
+    pub fn function_chains(mut self, values: impl IntoIterator<Item = FunctionChain>) -> Self {
+        self.value.function_chains = values.into_iter().collect();
+        self
+    }
+
+    /// Adds a function chain and returns the updated value.
+    pub fn add_function_chain(mut self, value: FunctionChain) -> Self {
+        self.value.function_chains.push(value);
+        self
+    }
+
+    /// Sets the hierarchical bucket aggregation and returns the updated value.
+    ///
+    /// Mutually exclusive with [`Self::group_by_field`] and [`Self::highlighter`]; when set,
+    /// `limit` is ignored, `SearchAggregation.size` controls the top-level bucket count, and
+    /// `offset` must remain zero.
+    pub fn search_aggregation(mut self, value: SearchAggregation) -> Self {
+        self.value.search_aggregation = Some(value);
         self
     }
 
@@ -1871,6 +1918,36 @@ fn validate_search_request(value: &SearchRequest) -> Result<()> {
     validate_search_extra_params(&value.extra_params)?;
     validate_finite_range_parameter("radius", value.radius)?;
     validate_finite_range_parameter("range_filter", value.range_filter)?;
+    if !value.function_chains.is_empty() && value.rerank.is_some() {
+        return Err(Error::validation(
+            "function_chains".into(),
+            "cannot be used together with rerank".into(),
+        ));
+    }
+    for chain in &value.function_chains {
+        chain.validate()?;
+    }
+    if let Some(aggregation) = &value.search_aggregation {
+        aggregation.validate()?;
+        if !value.group_by_field.is_empty() {
+            return Err(Error::validation(
+                "search_aggregation".into(),
+                "cannot be used together with group_by_field".into(),
+            ));
+        }
+        if value.offset > 0 {
+            return Err(Error::validation(
+                "offset".into(),
+                "cannot be used together with search_aggregation".into(),
+            ));
+        }
+        if value.highlighter.is_some() {
+            return Err(Error::validation(
+                "highlighter".into(),
+                "cannot be used together with search_aggregation".into(),
+            ));
+        }
+    }
     if !value.ids.is_empty() {
         if search_vectors_are_empty(&value.vectors) {
             return Ok(());
@@ -2013,13 +2090,14 @@ fn set_search_param(params: &mut Vec<common::KeyValuePair>, key: &str, value: im
 #[cfg(test)]
 mod search_request_tests {
     use super::{
-        EmbeddingList, HighlightQuery, HybridSearchRequest, LexicalHighlighter, SearchRequest,
-        SearchVectors, SubSearchRequest,
+        EmbeddingList, HighlightQuery, Highlighter, HybridSearchRequest, LexicalHighlighter,
+        SearchRequest, SearchVectors, SubSearchRequest,
     };
     use crate::proto::{common, milvus};
     use crate::v2::types::{
-        BoostRerank, DecayRerank, FunctionScore, Ids, MetricType, ModelRerank, SparseVector,
-        WeightedRerank,
+        col, fn_, BoostRerank, DecayRerank, FunctionChain, FunctionChainStage, FunctionScore,
+        HighlightType, Ids, MetricOp, MetricSpec, MetricType, ModelRerank, OrderSpec,
+        SearchAggregation, SortDirection, SparseVector, WeightedRerank,
     };
     use prost::Message;
     use serde_json::json;
@@ -2248,6 +2326,151 @@ mod search_request_tests {
             result,
             Err(crate::v2::error::Error::Validation(error)) if error.parameter() == "ids"
         ));
+    }
+
+    #[test]
+    fn search_rejects_function_chains_combined_with_rerank() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "$score",
+                fn_::num_combine(vec![col("$score"), col("popularity")], "sum", None),
+            );
+        let result = SearchRequest::builder()
+            .collection_name("books")
+            .vector_field("embedding")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .function_chains([chain])
+            .rerank(FunctionScore::new().add_function(BoostRerank::new().name("boost").weight(2.0)))
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(crate::v2::error::Error::Validation(error))
+                if error.parameter() == "function_chains"
+        ));
+    }
+
+    #[test]
+    fn search_rejects_aggregation_combined_with_group_by_field() {
+        let aggregation = SearchAggregation::new()
+            .fields(["category"])
+            .size(10)
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Sum).field_name("price"),
+            )
+            .add_order(
+                OrderSpec::new()
+                    .key("_count")
+                    .direction(SortDirection::Desc),
+            );
+        let result = SearchRequest::builder()
+            .collection_name("books")
+            .vector_field("embedding")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .group_by_field("category")
+            .search_aggregation(aggregation)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(crate::v2::error::Error::Validation(error))
+                if error.parameter() == "search_aggregation"
+        ));
+    }
+
+    #[test]
+    fn search_rejects_aggregation_combined_with_nonzero_offset() {
+        let aggregation = SearchAggregation::new()
+            .fields(["category"])
+            .size(10)
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Sum).field_name("price"),
+            )
+            .add_order(
+                OrderSpec::new()
+                    .key("_count")
+                    .direction(SortDirection::Desc),
+            );
+        let result = SearchRequest::builder()
+            .collection_name("books")
+            .vector_field("embedding")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .offset(1)
+            .search_aggregation(aggregation)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(crate::v2::error::Error::Validation(error))
+                if error.parameter() == "offset"
+        ));
+    }
+
+    #[test]
+    fn search_rejects_aggregation_combined_with_highlighter() {
+        let aggregation = SearchAggregation::new()
+            .fields(["category"])
+            .size(10)
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Sum).field_name("price"),
+            )
+            .add_order(
+                OrderSpec::new()
+                    .key("_count")
+                    .direction(SortDirection::Desc),
+            );
+        let result = SearchRequest::builder()
+            .collection_name("books")
+            .vector_field("embedding")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .highlighter(Highlighter::new().highlight_type(HighlightType::Lexical))
+            .search_aggregation(aggregation)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(crate::v2::error::Error::Validation(error))
+                if error.parameter() == "highlighter"
+        ));
+    }
+
+    #[test]
+    fn search_encodes_function_chains_and_aggregation_on_the_happy_path() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .sort("$score", true, None)
+            .limit(10, 0);
+        let aggregation = SearchAggregation::new()
+            .fields(["category"])
+            .size(10)
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Sum).field_name("price"),
+            )
+            .add_order(
+                OrderSpec::new()
+                    .key("_count")
+                    .direction(SortDirection::Desc),
+            );
+        let request = SearchRequest::builder()
+            .collection_name("books")
+            .vector_field("embedding")
+            .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+            .function_chains([chain])
+            .search_aggregation(aggregation)
+            .build()
+            .expect("valid request with function chains and aggregation")
+            .into_proto("default", 0)
+            .expect("encode request");
+
+        assert_eq!(request.function_chains.len(), 1);
+        assert_eq!(request.function_chains[0].ops.len(), 2);
+        assert_eq!(request.function_chains[0].ops[0].op, "sort");
+        assert!(request.search_aggregation.is_some());
     }
 
     #[test]

--- a/src/v2/response/dql.rs
+++ b/src/v2/response/dql.rs
@@ -23,7 +23,7 @@
 use crate::proto::{milvus, schema};
 use crate::v2::error::{Error, Result};
 use crate::v2::types::Ids;
-use crate::v2::types::{DataType, FieldData, SparseVector};
+use crate::v2::types::{group_aggregation_buckets, DataType, FieldData, SparseVector};
 pub use crate::v2::types::{HighlightResult, QueryResults, SearchResults, SingleResult};
 use std::collections::{HashMap, HashSet};
 
@@ -1085,6 +1085,11 @@ impl SearchResponse {
             results: SearchResults {
                 results: single_results,
                 recalls: result.recalls,
+                agg_buckets: group_aggregation_buckets(
+                    result.agg_buckets,
+                    result.agg_topks,
+                    result.num_queries,
+                )?,
             },
         })
     }
@@ -1114,6 +1119,7 @@ impl SearchResponse {
             results: SearchResults {
                 results: vec![remaining],
                 recalls: self.results.recalls.clone(),
+                agg_buckets: self.results.agg_buckets.clone(),
             },
             session_timestamp: self.session_timestamp,
             cost: self.cost,
@@ -1739,7 +1745,7 @@ pub type HybridSearchResponse = SearchResponse;
 mod tests {
     use super::{field_data, split_field_data, QueryResponse, SearchResponse};
     use crate::proto::{common, milvus, schema};
-    use crate::v2::types::{DataType, FieldData};
+    use crate::v2::types::{AggregationBucketValue, DataType, FieldData};
 
     #[test]
     fn decode_field_data_prefers_field_specific_validity() {
@@ -3098,6 +3104,49 @@ mod tests {
 
         assert_eq!(search.results().len().to_owned(), 1);
         assert!(search.results().get_results()[0].is_empty());
+    }
+
+    #[test]
+    fn search_response_groups_aggregation_buckets_per_query() {
+        // nq=2 with zero result rows; the first query owns one top-level bucket (agg_topks=[1, 0]).
+        let search = SearchResponse::from_proto(milvus::SearchResults {
+            results: Some(schema::SearchResultData {
+                num_queries: 2,
+                top_k: 0,
+                topks: vec![0, 0],
+                scores: vec![],
+                ids: Some(schema::IDs::default()),
+                primary_field_name: "id".into(),
+                agg_buckets: vec![schema::AggBucket {
+                    key: vec![schema::BucketKeyEntry {
+                        field_id: 1,
+                        field_name: "category".into(),
+                        value: Some(schema::bucket_key_entry::Value::StringVal("tech".into())),
+                    }],
+                    count: 3,
+                    metrics: std::collections::HashMap::new(),
+                    hits: vec![],
+                    sub_groups: vec![],
+                }],
+                agg_topks: vec![1, 0],
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .expect("decode aggregation search response");
+
+        assert_eq!(search.results().get_agg_buckets().len(), 2);
+        assert_eq!(search.results().get_agg_buckets()[0].len(), 1);
+        let bucket = &search.results().get_agg_buckets()[0][0];
+        assert_eq!(bucket.get_count(), 3);
+        assert_eq!(bucket.get_key()[0].get_field_name(), "category");
+        assert_eq!(
+            bucket.get_key()[0].get_value(),
+            &AggregationBucketValue::String("tech".to_owned())
+        );
+        assert!(search.results().get_agg_buckets()[1].is_empty());
+        assert!(search.results().get_results()[0].is_empty());
+        assert!(search.results().get_results()[1].is_empty());
     }
 }
 

--- a/src/v2/types/aggregation.rs
+++ b/src/v2/types/aggregation.rs
@@ -1,0 +1,815 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hierarchical bucket aggregation types for the search interface.
+//!
+//! [`SearchAggregation`] groups search results by one or more fields, optionally computing
+//! [`MetricSpec`] aggregations, ordering the resulting buckets, returning [`TopHitsSpec`]
+//! document snapshots, and nesting recursive [`SearchAggregation`] levels, mirroring pymilvus's
+//! `SearchAggregation` and the Java SDK's `aggregation` package.
+
+use crate::proto::common;
+use crate::v2::error::{Error, Result};
+use std::collections::HashMap;
+
+/// Keys that ordering rules may reference without being defined metrics.
+const SPECIAL_ORDER_KEYS: [&str; 2] = ["_count", "_key"];
+
+///////////////////////////////////////////////////////////////////////////////
+// MetricOp
+///////////////////////////////////////////////////////////////////////////////
+/// Aggregation operator applied to a field within a bucket.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MetricOp {
+    #[default]
+    /// Represents the Avg case.
+    Avg,
+    /// Represents the Sum case.
+    Sum,
+    /// Represents the Count case.
+    Count,
+    /// Represents the Min case.
+    Min,
+    /// Represents the Max case.
+    Max,
+}
+
+impl MetricOp {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Avg => "avg",
+            Self::Sum => "sum",
+            Self::Count => "count",
+            Self::Min => "min",
+            Self::Max => "max",
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SortDirection
+///////////////////////////////////////////////////////////////////////////////
+/// Sort direction used by aggregation order and top-hits rules.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SortDirection {
+    /// Represents the Asc case.
+    Asc,
+    #[default]
+    /// Represents the Desc case.
+    Desc,
+}
+
+impl SortDirection {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// MetricSpec
+///////////////////////////////////////////////////////////////////////////////
+/// A single metric aggregation over a field, keyed by alias in a [`SearchAggregation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MetricSpec {
+    pub(crate) op: MetricOp,
+    pub(crate) field_name: String,
+}
+
+impl MetricSpec {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            op: MetricOp::Avg,
+            field_name: String::new(),
+        }
+    }
+
+    /// Sets the operator and returns the updated value.
+    pub fn op(mut self, value: MetricOp) -> Self {
+        self.op = value;
+        self
+    }
+
+    /// Sets the operator and returns this value for further mutation.
+    pub fn set_op(&mut self, value: MetricOp) -> &mut Self {
+        self.op = value;
+        self
+    }
+
+    /// Sets the field name and returns the updated value.
+    pub fn field_name(mut self, value: impl Into<String>) -> Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Sets the field name and returns this value for further mutation.
+    pub fn set_field_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Returns the operator.
+    pub fn get_op(&self) -> MetricOp {
+        self.op
+    }
+
+    /// Returns the field name.
+    pub fn get_field_name(&self) -> &str {
+        &self.field_name
+    }
+
+    pub(crate) fn into_proto(self) -> common::MetricAggSpec {
+        common::MetricAggSpec {
+            op: self.op.as_str().to_owned(),
+            field_name: self.field_name,
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SortSpec
+///////////////////////////////////////////////////////////////////////////////
+/// Field sort rule used by a top-hits snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SortSpec {
+    pub(crate) field_name: String,
+    pub(crate) direction: SortDirection,
+    pub(crate) null_first: bool,
+}
+
+impl SortSpec {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            field_name: String::new(),
+            direction: SortDirection::Desc,
+            null_first: false,
+        }
+    }
+
+    /// Sets the field name and returns the updated value.
+    pub fn field_name(mut self, value: impl Into<String>) -> Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Sets the field name and returns this value for further mutation.
+    pub fn set_field_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Sets the direction and returns the updated value.
+    pub fn direction(mut self, value: SortDirection) -> Self {
+        self.direction = value;
+        self
+    }
+
+    /// Sets the direction and returns this value for further mutation.
+    pub fn set_direction(&mut self, value: SortDirection) -> &mut Self {
+        self.direction = value;
+        self
+    }
+
+    /// Sets whether null values sort first and returns the updated value.
+    pub fn null_first(mut self, value: bool) -> Self {
+        self.null_first = value;
+        self
+    }
+
+    /// Sets whether null values sort first and returns this value for further mutation.
+    pub fn set_null_first(&mut self, value: bool) -> &mut Self {
+        self.null_first = value;
+        self
+    }
+
+    /// Returns the field name.
+    pub fn get_field_name(&self) -> &str {
+        &self.field_name
+    }
+
+    /// Returns the direction.
+    pub fn get_direction(&self) -> SortDirection {
+        self.direction
+    }
+
+    /// Returns whether null values sort first.
+    pub fn is_null_first(&self) -> bool {
+        self.null_first
+    }
+
+    pub(crate) fn into_proto(self) -> common::SortSpec {
+        common::SortSpec {
+            field_name: self.field_name,
+            direction: self.direction.as_str().to_owned(),
+            null_first: self.null_first,
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// OrderSpec
+///////////////////////////////////////////////////////////////////////////////
+/// Ordering rule applied to the buckets at an aggregation level.
+///
+/// `key` is a metric alias or one of the special keys `_count`/`_key`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct OrderSpec {
+    pub(crate) key: String,
+    pub(crate) direction: SortDirection,
+    pub(crate) null_first: bool,
+}
+
+impl OrderSpec {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            key: String::new(),
+            direction: SortDirection::Desc,
+            null_first: false,
+        }
+    }
+
+    /// Sets the key and returns the updated value.
+    pub fn key(mut self, value: impl Into<String>) -> Self {
+        self.key = value.into();
+        self
+    }
+
+    /// Sets the key and returns this value for further mutation.
+    pub fn set_key(&mut self, value: impl Into<String>) -> &mut Self {
+        self.key = value.into();
+        self
+    }
+
+    /// Sets the direction and returns the updated value.
+    pub fn direction(mut self, value: SortDirection) -> Self {
+        self.direction = value;
+        self
+    }
+
+    /// Sets the direction and returns this value for further mutation.
+    pub fn set_direction(&mut self, value: SortDirection) -> &mut Self {
+        self.direction = value;
+        self
+    }
+
+    /// Sets whether null values sort first and returns the updated value.
+    pub fn null_first(mut self, value: bool) -> Self {
+        self.null_first = value;
+        self
+    }
+
+    /// Sets whether null values sort first and returns this value for further mutation.
+    pub fn set_null_first(&mut self, value: bool) -> &mut Self {
+        self.null_first = value;
+        self
+    }
+
+    /// Returns the key.
+    pub fn get_key(&self) -> &str {
+        &self.key
+    }
+
+    /// Returns the direction.
+    pub fn get_direction(&self) -> SortDirection {
+        self.direction
+    }
+
+    /// Returns whether null values sort first.
+    pub fn is_null_first(&self) -> bool {
+        self.null_first
+    }
+
+    pub(crate) fn into_proto(self) -> common::OrderSpec {
+        common::OrderSpec {
+            key: self.key,
+            direction: self.direction.as_str().to_owned(),
+            null_first: self.null_first,
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// TopHitsSpec
+///////////////////////////////////////////////////////////////////////////////
+/// Document snapshot returned for each bucket at an aggregation level.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TopHitsSpec {
+    pub(crate) size: i64,
+    pub(crate) sort: Vec<SortSpec>,
+}
+
+impl TopHitsSpec {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            size: 0,
+            sort: Vec::new(),
+        }
+    }
+
+    /// Sets the size and returns the updated value.
+    pub fn size(mut self, value: i64) -> Self {
+        self.size = value;
+        self
+    }
+
+    /// Sets the size and returns this value for further mutation.
+    pub fn set_size(&mut self, value: i64) -> &mut Self {
+        self.size = value;
+        self
+    }
+
+    /// Sets the sort rules and returns the updated value.
+    pub fn sort(mut self, values: impl IntoIterator<Item = SortSpec>) -> Self {
+        self.sort = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the sort rules and returns this value for further mutation.
+    pub fn set_sort(&mut self, values: impl IntoIterator<Item = SortSpec>) -> &mut Self {
+        self.sort = values.into_iter().collect();
+        self
+    }
+
+    /// Appends a sort rule and returns the updated value.
+    pub fn add_sort(mut self, value: SortSpec) -> Self {
+        self.sort.push(value);
+        self
+    }
+
+    /// Returns the size.
+    pub fn get_size(&self) -> i64 {
+        self.size
+    }
+
+    /// Returns the sort rules.
+    pub fn get_sort(&self) -> &[SortSpec] {
+        &self.sort
+    }
+
+    pub(crate) fn into_proto(self) -> common::TopHitsSpec {
+        common::TopHitsSpec {
+            size: self.size,
+            sort: self.sort.into_iter().map(SortSpec::into_proto).collect(),
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SearchAggregation
+///////////////////////////////////////////////////////////////////////////////
+/// One level of hierarchical bucket aggregation, recursively nestable.
+///
+/// Attach the aggregation to a search request with
+/// [`SearchRequestBuilder::search_aggregation`](crate::v2::request::dql::SearchRequestBuilder::search_aggregation).
+/// It is mutually exclusive with `group_by_field`; when set, the search `limit` is ignored and
+/// [`Self::size`] controls the top-level bucket count.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct SearchAggregation {
+    pub(crate) fields: Vec<String>,
+    pub(crate) size: i64,
+    pub(crate) metrics: HashMap<String, MetricSpec>,
+    pub(crate) order: Vec<OrderSpec>,
+    pub(crate) top_hits: Option<TopHitsSpec>,
+    pub(crate) sub_aggregation: Option<Box<SearchAggregation>>,
+}
+
+impl SearchAggregation {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            size: 0,
+            metrics: HashMap::new(),
+            order: Vec::new(),
+            top_hits: None,
+            sub_aggregation: None,
+        }
+    }
+
+    /// Sets the group-by fields and returns the updated value.
+    pub fn fields(mut self, values: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.fields = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the group-by fields and returns this value for further mutation.
+    pub fn set_fields(&mut self, values: impl IntoIterator<Item = impl Into<String>>) -> &mut Self {
+        self.fields = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Returns the group-by fields.
+    pub fn get_fields(&self) -> &[String] {
+        &self.fields
+    }
+
+    /// Appends a group-by field and returns the updated value.
+    pub fn add_field(mut self, value: impl Into<String>) -> Self {
+        self.fields.push(value.into());
+        self
+    }
+
+    /// Sets the maximum number of buckets returned at this level and returns the updated value.
+    pub fn size(mut self, value: i64) -> Self {
+        self.size = value;
+        self
+    }
+
+    /// Sets the maximum number of buckets returned at this level and returns this value for
+    /// further mutation.
+    pub fn set_size(&mut self, value: i64) -> &mut Self {
+        self.size = value;
+        self
+    }
+
+    /// Returns the maximum number of buckets returned at this level.
+    pub fn get_size(&self) -> i64 {
+        self.size
+    }
+
+    /// Sets the metric aggregations keyed by alias and returns the updated value.
+    pub fn metrics(mut self, values: impl IntoIterator<Item = (String, MetricSpec)>) -> Self {
+        self.metrics = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the metric aggregations keyed by alias and returns this value for further mutation.
+    pub fn set_metrics(
+        &mut self,
+        values: impl IntoIterator<Item = (String, MetricSpec)>,
+    ) -> &mut Self {
+        self.metrics = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the metric aggregations keyed by alias.
+    pub fn get_metrics(&self) -> &HashMap<String, MetricSpec> {
+        &self.metrics
+    }
+
+    /// Adds a metric aggregation under `alias` and returns the updated value.
+    pub fn add_metric(mut self, alias: impl Into<String>, value: MetricSpec) -> Self {
+        self.metrics.insert(alias.into(), value);
+        self
+    }
+
+    /// Sets the ordering rules and returns the updated value.
+    pub fn order(mut self, values: impl IntoIterator<Item = OrderSpec>) -> Self {
+        self.order = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the ordering rules and returns this value for further mutation.
+    pub fn set_order(&mut self, values: impl IntoIterator<Item = OrderSpec>) -> &mut Self {
+        self.order = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the ordering rules.
+    pub fn get_order(&self) -> &[OrderSpec] {
+        &self.order
+    }
+
+    /// Appends an ordering rule and returns the updated value.
+    pub fn add_order(mut self, value: OrderSpec) -> Self {
+        self.order.push(value);
+        self
+    }
+
+    /// Sets the top-hits snapshot and returns the updated value.
+    pub fn top_hits(mut self, value: TopHitsSpec) -> Self {
+        self.top_hits = Some(value);
+        self
+    }
+
+    /// Sets the top-hits snapshot and returns this value for further mutation.
+    pub fn set_top_hits(&mut self, value: TopHitsSpec) -> &mut Self {
+        self.top_hits = Some(value);
+        self
+    }
+
+    /// Returns the top-hits snapshot, if configured.
+    pub fn get_top_hits(&self) -> Option<&TopHitsSpec> {
+        self.top_hits.as_ref()
+    }
+
+    /// Sets the nested sub-aggregation and returns the updated value.
+    pub fn sub_aggregation(mut self, value: SearchAggregation) -> Self {
+        self.sub_aggregation = Some(Box::new(value));
+        self
+    }
+
+    /// Sets the nested sub-aggregation and returns this value for further mutation.
+    pub fn set_sub_aggregation(&mut self, value: SearchAggregation) -> &mut Self {
+        self.sub_aggregation = Some(Box::new(value));
+        self
+    }
+
+    /// Returns the nested sub-aggregation, if configured.
+    pub fn get_sub_aggregation(&self) -> Option<&SearchAggregation> {
+        self.sub_aggregation.as_deref()
+    }
+
+    /// Validates the aggregation spec before it is attached to a search request.
+    pub fn validate(&self) -> Result<()> {
+        if self.fields.is_empty() {
+            return Err(Error::validation(
+                "search_aggregation".into(),
+                "fields must contain at least one field".into(),
+            ));
+        }
+        if self.fields.iter().any(String::is_empty) {
+            return Err(Error::validation(
+                "search_aggregation".into(),
+                "fields must not contain empty values".into(),
+            ));
+        }
+        if self.size <= 0 {
+            return Err(Error::validation(
+                "search_aggregation".into(),
+                "size must be a positive integer".into(),
+            ));
+        }
+        for (alias, metric) in &self.metrics {
+            if alias.is_empty() {
+                return Err(Error::validation(
+                    "search_aggregation".into(),
+                    "metric aliases must not be empty".into(),
+                ));
+            }
+            if metric.field_name.is_empty() {
+                return Err(Error::validation(
+                    "search_aggregation".into(),
+                    format!("metric {alias:?} must specify a non-empty field name"),
+                ));
+            }
+            if metric.field_name == "*" && metric.op != MetricOp::Count {
+                return Err(Error::validation(
+                    "search_aggregation".into(),
+                    format!(
+                        "metric {alias:?}: field \"*\" is only supported with the count operator"
+                    ),
+                ));
+            }
+        }
+        if let Some(top_hits) = &self.top_hits {
+            if top_hits.size <= 0 {
+                return Err(Error::validation(
+                    "search_aggregation".into(),
+                    "top_hits.size must be a positive integer".into(),
+                ));
+            }
+            for sort in &top_hits.sort {
+                if sort.field_name.is_empty() {
+                    return Err(Error::validation(
+                        "search_aggregation".into(),
+                        "top_hits sort rules must not use an empty field name".into(),
+                    ));
+                }
+            }
+        }
+        let allowed_keys: std::collections::HashSet<&str> = self
+            .metrics
+            .keys()
+            .map(String::as_str)
+            .chain(SPECIAL_ORDER_KEYS.iter().copied())
+            .collect();
+        for order in &self.order {
+            if !allowed_keys.contains(order.key.as_str()) {
+                return Err(Error::validation(
+                    "search_aggregation".into(),
+                    format!(
+                        "order key {:?} must be a metric alias or one of {SPECIAL_ORDER_KEYS:?}",
+                        order.key
+                    ),
+                ));
+            }
+        }
+        if let Some(sub) = &self.sub_aggregation {
+            sub.validate()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn into_proto(self) -> Result<common::SearchAggregationSpec> {
+        self.validate()?;
+        Ok(common::SearchAggregationSpec {
+            fields: self.fields,
+            size: self.size,
+            metrics: self
+                .metrics
+                .into_iter()
+                .map(|(alias, metric)| (alias, metric.into_proto()))
+                .collect(),
+            order: self.order.into_iter().map(OrderSpec::into_proto).collect(),
+            top_hits: self.top_hits.map(TopHitsSpec::into_proto),
+            sub_aggregation: self
+                .sub_aggregation
+                .map(|sub| sub.into_proto())
+                .transpose()?
+                .map(Box::new),
+            ..Default::default()
+        })
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test Cases
+///////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_spec() -> SearchAggregation {
+        SearchAggregation::new()
+            .fields(["category"])
+            .size(10)
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Sum).field_name("price"),
+            )
+            .add_order(
+                OrderSpec::new()
+                    .key("_count")
+                    .direction(SortDirection::Desc),
+            )
+    }
+
+    #[test]
+    fn validate_accepts_valid_spec() {
+        valid_spec().validate().expect("valid aggregation spec");
+        valid_spec()
+            .add_metric(
+                "distinct",
+                MetricSpec::new().op(MetricOp::Count).field_name("*"),
+            )
+            .validate()
+            .expect("count over * is valid");
+    }
+
+    #[test]
+    fn validate_rejects_empty_fields() {
+        let error = SearchAggregation::new()
+            .size(10)
+            .validate()
+            .expect_err("empty fields must be rejected");
+        assert!(error.to_string().contains("fields"));
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_size() {
+        let error = SearchAggregation::new()
+            .fields(["category"])
+            .size(0)
+            .validate()
+            .expect_err("non-positive size must be rejected");
+        assert!(error.to_string().contains("size"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_order_key() {
+        let error = valid_spec()
+            .add_order(OrderSpec::new().key("bogus").direction(SortDirection::Asc))
+            .validate()
+            .expect_err("unknown order key must be rejected");
+        assert!(error.to_string().contains("order key"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_metric_field_name() {
+        let error = valid_spec()
+            .add_metric("empty", MetricSpec::new().op(MetricOp::Avg).field_name(""))
+            .validate()
+            .expect_err("empty metric field name must be rejected");
+        assert!(error.to_string().contains("field name"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_metric_alias() {
+        let error = valid_spec()
+            .add_metric("", MetricSpec::new().op(MetricOp::Avg).field_name("price"))
+            .validate()
+            .expect_err("empty metric alias must be rejected");
+        assert!(error.to_string().contains("alias"));
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_top_hits_size() {
+        let error = valid_spec()
+            .top_hits(TopHitsSpec::new().size(0))
+            .validate()
+            .expect_err("non-positive top-hits size must be rejected");
+        assert!(error.to_string().contains("top_hits"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_top_hits_sort_field() {
+        let error = valid_spec()
+            .top_hits(
+                TopHitsSpec::new()
+                    .size(3)
+                    .add_sort(SortSpec::new().field_name("").direction(SortDirection::Asc)),
+            )
+            .validate()
+            .expect_err("empty top-hits sort field must be rejected");
+        assert!(error.to_string().contains("sort"));
+    }
+
+    #[test]
+    fn validate_rejects_wildcard_with_non_count_metric() {
+        let error = valid_spec()
+            .add_metric("bad", MetricSpec::new().op(MetricOp::Sum).field_name("*"))
+            .validate()
+            .expect_err("wildcard with non-count metric must be rejected");
+        assert!(error.to_string().contains("count"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_sub_aggregation() {
+        let error = valid_spec()
+            .sub_aggregation(SearchAggregation::new().size(5))
+            .validate()
+            .expect_err("invalid sub-aggregation must be rejected");
+        assert!(error.to_string().contains("fields"));
+    }
+
+    #[test]
+    fn metric_spec_encodes_to_proto() {
+        let proto = MetricSpec::new()
+            .op(MetricOp::Sum)
+            .field_name("price")
+            .into_proto();
+        assert_eq!(proto.op, "sum");
+        assert_eq!(proto.field_name, "price");
+    }
+
+    #[test]
+    fn search_aggregation_encodes_to_proto() {
+        let proto = valid_spec()
+            .add_metric(
+                "total",
+                MetricSpec::new().op(MetricOp::Avg).field_name("rating"),
+            )
+            .top_hits(
+                TopHitsSpec::new().size(3).add_sort(
+                    SortSpec::new()
+                        .field_name("price")
+                        .direction(SortDirection::Asc),
+                ),
+            )
+            .sub_aggregation(
+                SearchAggregation::new()
+                    .fields(["region"])
+                    .size(5)
+                    .add_metric("cnt", MetricSpec::new().op(MetricOp::Count).field_name("*")),
+            )
+            .into_proto()
+            .expect("valid aggregation spec");
+        assert_eq!(proto.fields, ["category"]);
+        assert_eq!(proto.size, 10);
+        assert_eq!(
+            proto.metrics.get("total").map(|m| m.op.as_str()),
+            Some("avg")
+        );
+        assert_eq!(proto.order[0].key, "_count");
+        assert_eq!(proto.order[0].direction, "desc");
+        let top_hits = proto.top_hits.expect("top hits configured");
+        assert_eq!(top_hits.size, 3);
+        assert_eq!(top_hits.sort[0].field_name, "price");
+        assert_eq!(top_hits.sort[0].direction, "asc");
+        let sub = proto.sub_aggregation.expect("sub-aggregation configured");
+        assert_eq!(sub.fields, ["region"]);
+        assert_eq!(sub.metrics.get("cnt").map(|m| m.op.as_str()), Some("count"));
+    }
+}

--- a/src/v2/types/dql.rs
+++ b/src/v2/types/dql.rs
@@ -2348,6 +2348,636 @@ fn result_json_kind(value: &Value) -> &'static str {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// AggregationBucketValue
+///////////////////////////////////////////////////////////////////////////////
+/// Typed grouping-key value of an aggregation bucket.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AggregationBucketValue {
+    /// Represents an integer value.
+    Int(i64),
+    /// Represents a string value.
+    String(String),
+    /// Represents a boolean value.
+    Bool(bool),
+}
+
+impl AggregationBucketValue {
+    pub(crate) fn from_proto(value: Option<schema::bucket_key_entry::Value>) -> Result<Self> {
+        use schema::bucket_key_entry::Value;
+        match value {
+            Some(Value::IntVal(value)) => Ok(Self::Int(value)),
+            Some(Value::StringVal(value)) => Ok(Self::String(value)),
+            Some(Value::BoolVal(value)) => Ok(Self::Bool(value)),
+            None => Err(Error::MalformedResponse(
+                "aggregation bucket key contains no value".into(),
+            )),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationMetricValue
+///////////////////////////////////////////////////////////////////////////////
+/// Typed metric result of an aggregation bucket.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AggregationMetricValue {
+    /// Represents an integer value.
+    Int(i64),
+    /// Represents a floating-point value.
+    Double(f64),
+    /// Represents a string value.
+    String(String),
+    /// Represents a boolean value.
+    Bool(bool),
+}
+
+impl AggregationMetricValue {
+    pub(crate) fn from_proto(value: Option<schema::metric_value::Value>) -> Result<Self> {
+        use schema::metric_value::Value;
+        match value {
+            Some(Value::IntVal(value)) => Ok(Self::Int(value)),
+            Some(Value::DoubleVal(value)) => Ok(Self::Double(value)),
+            Some(Value::StringVal(value)) => Ok(Self::String(value)),
+            Some(Value::BoolVal(value)) => Ok(Self::Bool(value)),
+            None => Err(Error::MalformedResponse(
+                "aggregation bucket metric contains no value".into(),
+            )),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationHitFieldValue
+///////////////////////////////////////////////////////////////////////////////
+/// Typed field value of an aggregation hit.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AggregationHitFieldValue {
+    /// Represents an integer value.
+    Int(i64),
+    /// Represents a boolean value.
+    Bool(bool),
+    /// Represents a float value.
+    Float(f32),
+    /// Represents a double value.
+    Double(f64),
+    /// Represents a string value.
+    String(String),
+    /// Represents a bytes value.
+    Bytes(Vec<u8>),
+}
+
+impl AggregationHitFieldValue {
+    pub(crate) fn from_proto(value: Option<schema::agg_hit_field::Value>) -> Result<Self> {
+        use schema::agg_hit_field::Value;
+        match value {
+            Some(Value::IntVal(value)) => Ok(Self::Int(value)),
+            Some(Value::BoolVal(value)) => Ok(Self::Bool(value)),
+            Some(Value::FloatVal(value)) => Ok(Self::Float(value)),
+            Some(Value::DoubleVal(value)) => Ok(Self::Double(value)),
+            Some(Value::StringVal(value)) => Ok(Self::String(value)),
+            Some(Value::BytesVal(value)) => Ok(Self::Bytes(value)),
+            None => Err(Error::MalformedResponse(
+                "aggregation hit field contains no value".into(),
+            )),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationHitPk
+///////////////////////////////////////////////////////////////////////////////
+/// Primary key of an aggregation hit.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AggregationHitPk {
+    /// Represents an integer primary key.
+    Int(i64),
+    /// Represents a string primary key.
+    String(String),
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationHitField
+///////////////////////////////////////////////////////////////////////////////
+/// One returned field of an aggregation hit.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct AggregationHitField {
+    pub(crate) field_id: i64,
+    pub(crate) field_name: String,
+    pub(crate) value: AggregationHitFieldValue,
+}
+
+impl AggregationHitField {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            field_id: 0,
+            field_name: String::new(),
+            value: AggregationHitFieldValue::Int(0),
+        }
+    }
+
+    /// Sets the field id and returns the updated value.
+    pub fn field_id(mut self, value: i64) -> Self {
+        self.field_id = value;
+        self
+    }
+
+    /// Sets the field id and returns this value for further mutation.
+    pub fn set_field_id(&mut self, value: i64) -> &mut Self {
+        self.field_id = value;
+        self
+    }
+
+    /// Returns the field id.
+    pub fn get_field_id(&self) -> i64 {
+        self.field_id
+    }
+
+    /// Sets the field name and returns the updated value.
+    pub fn field_name(mut self, value: impl Into<String>) -> Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Sets the field name and returns this value for further mutation.
+    pub fn set_field_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Returns the field name.
+    pub fn get_field_name(&self) -> &str {
+        &self.field_name
+    }
+
+    /// Sets the field value and returns the updated value.
+    pub fn value(mut self, value: AggregationHitFieldValue) -> Self {
+        self.value = value;
+        self
+    }
+
+    /// Sets the field value and returns this value for further mutation.
+    pub fn set_value(&mut self, value: AggregationHitFieldValue) -> &mut Self {
+        self.value = value;
+        self
+    }
+
+    /// Returns the field value.
+    pub fn get_value(&self) -> &AggregationHitFieldValue {
+        &self.value
+    }
+
+    pub(crate) fn from_proto(value: schema::AggHitField) -> Result<Self> {
+        Ok(Self {
+            field_id: value.field_id,
+            field_name: if value.field_name.is_empty() {
+                value.field_id.to_string()
+            } else {
+                value.field_name
+            },
+            value: AggregationHitFieldValue::from_proto(value.value)?,
+        })
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationHit
+///////////////////////////////////////////////////////////////////////////////
+/// One document inside an aggregation bucket.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct AggregationHit {
+    pub(crate) pk: Option<AggregationHitPk>,
+    pub(crate) score: f32,
+    pub(crate) fields: Vec<AggregationHitField>,
+}
+
+impl AggregationHit {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            pk: None,
+            score: 0.0,
+            fields: Vec::new(),
+        }
+    }
+
+    /// Sets the primary key and returns the updated value.
+    pub fn pk(mut self, value: AggregationHitPk) -> Self {
+        self.pk = Some(value);
+        self
+    }
+
+    /// Sets the primary key and returns this value for further mutation.
+    pub fn set_pk(&mut self, value: AggregationHitPk) -> &mut Self {
+        self.pk = Some(value);
+        self
+    }
+
+    /// Returns the primary key.
+    pub fn get_pk(&self) -> Option<&AggregationHitPk> {
+        self.pk.as_ref()
+    }
+
+    /// Sets the score and returns the updated value.
+    pub fn score(mut self, value: f32) -> Self {
+        self.score = value;
+        self
+    }
+
+    /// Sets the score and returns this value for further mutation.
+    pub fn set_score(&mut self, value: f32) -> &mut Self {
+        self.score = value;
+        self
+    }
+
+    /// Returns the score.
+    pub fn get_score(&self) -> f32 {
+        self.score
+    }
+
+    /// Sets the returned fields and returns the updated value.
+    pub fn fields(mut self, values: impl IntoIterator<Item = AggregationHitField>) -> Self {
+        self.fields = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the returned fields and returns this value for further mutation.
+    pub fn set_fields(
+        &mut self,
+        values: impl IntoIterator<Item = AggregationHitField>,
+    ) -> &mut Self {
+        self.fields = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the returned fields.
+    pub fn get_fields(&self) -> &[AggregationHitField] {
+        &self.fields
+    }
+
+    /// Appends a returned field and returns the updated value.
+    pub fn add_field(mut self, value: AggregationHitField) -> Self {
+        self.fields.push(value);
+        self
+    }
+
+    pub(crate) fn from_proto(value: schema::AggHit) -> Result<Self> {
+        use schema::agg_hit::Pk;
+        let pk = match value.pk {
+            Some(Pk::IntPk(value)) => Some(AggregationHitPk::Int(value)),
+            Some(Pk::StrPk(value)) => Some(AggregationHitPk::String(value)),
+            None => None,
+        };
+        let fields = value
+            .fields
+            .into_iter()
+            .map(AggregationHitField::from_proto)
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            pk,
+            score: value.score,
+            fields,
+        })
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// BucketKeyEntry
+///////////////////////////////////////////////////////////////////////////////
+/// One entry of a composite grouping key in an aggregation bucket.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct BucketKeyEntry {
+    pub(crate) field_id: i64,
+    pub(crate) field_name: String,
+    pub(crate) value: AggregationBucketValue,
+}
+
+impl BucketKeyEntry {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            field_id: 0,
+            field_name: String::new(),
+            value: AggregationBucketValue::Int(0),
+        }
+    }
+
+    /// Sets the field id and returns the updated value.
+    pub fn field_id(mut self, value: i64) -> Self {
+        self.field_id = value;
+        self
+    }
+
+    /// Sets the field id and returns this value for further mutation.
+    pub fn set_field_id(&mut self, value: i64) -> &mut Self {
+        self.field_id = value;
+        self
+    }
+
+    /// Returns the field id.
+    pub fn get_field_id(&self) -> i64 {
+        self.field_id
+    }
+
+    /// Sets the field name and returns the updated value.
+    pub fn field_name(mut self, value: impl Into<String>) -> Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Sets the field name and returns this value for further mutation.
+    pub fn set_field_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.field_name = value.into();
+        self
+    }
+
+    /// Returns the field name.
+    pub fn get_field_name(&self) -> &str {
+        &self.field_name
+    }
+
+    /// Sets the field value and returns the updated value.
+    pub fn value(mut self, value: AggregationBucketValue) -> Self {
+        self.value = value;
+        self
+    }
+
+    /// Sets the field value and returns this value for further mutation.
+    pub fn set_value(&mut self, value: AggregationBucketValue) -> &mut Self {
+        self.value = value;
+        self
+    }
+
+    /// Returns the field value.
+    pub fn get_value(&self) -> &AggregationBucketValue {
+        &self.value
+    }
+
+    pub(crate) fn from_proto(value: schema::BucketKeyEntry) -> Result<Self> {
+        Ok(Self {
+            field_id: value.field_id,
+            field_name: if value.field_name.is_empty() {
+                value.field_id.to_string()
+            } else {
+                value.field_name
+            },
+            value: AggregationBucketValue::from_proto(value.value)?,
+        })
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// AggregationBucket
+///////////////////////////////////////////////////////////////////////////////
+/// One bucket in the hierarchical aggregation result tree.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct AggregationBucket {
+    pub(crate) key: Vec<BucketKeyEntry>,
+    pub(crate) count: i64,
+    pub(crate) metrics: HashMap<String, AggregationMetricValue>,
+    pub(crate) hits: Vec<AggregationHit>,
+    pub(crate) sub_groups: Vec<AggregationBucket>,
+}
+
+impl AggregationBucket {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            key: Vec::new(),
+            count: 0,
+            metrics: HashMap::new(),
+            hits: Vec::new(),
+            sub_groups: Vec::new(),
+        }
+    }
+
+    /// Sets the composite grouping key and returns the updated value.
+    pub fn key(mut self, values: impl IntoIterator<Item = BucketKeyEntry>) -> Self {
+        self.key = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the composite grouping key and returns this value for further mutation.
+    pub fn set_key(&mut self, values: impl IntoIterator<Item = BucketKeyEntry>) -> &mut Self {
+        self.key = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the composite grouping key.
+    pub fn get_key(&self) -> &[BucketKeyEntry] {
+        &self.key
+    }
+
+    /// Appends a grouping-key entry and returns the updated value.
+    pub fn add_key(mut self, value: BucketKeyEntry) -> Self {
+        self.key.push(value);
+        self
+    }
+
+    /// Sets the number of documents in this bucket and returns the updated value.
+    pub fn count(mut self, value: i64) -> Self {
+        self.count = value;
+        self
+    }
+
+    /// Sets the number of documents in this bucket and returns this value for further mutation.
+    pub fn set_count(&mut self, value: i64) -> &mut Self {
+        self.count = value;
+        self
+    }
+
+    /// Returns the number of documents in this bucket.
+    pub fn get_count(&self) -> i64 {
+        self.count
+    }
+
+    /// Sets the metric results keyed by alias and returns the updated value.
+    pub fn metrics(
+        mut self,
+        values: impl IntoIterator<Item = (String, AggregationMetricValue)>,
+    ) -> Self {
+        self.metrics = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the metric results keyed by alias and returns this value for further mutation.
+    pub fn set_metrics(
+        &mut self,
+        values: impl IntoIterator<Item = (String, AggregationMetricValue)>,
+    ) -> &mut Self {
+        self.metrics = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the metric results keyed by alias.
+    pub fn get_metrics(&self) -> &HashMap<String, AggregationMetricValue> {
+        &self.metrics
+    }
+
+    /// Adds a metric result under `alias` and returns the updated value.
+    pub fn add_metric(mut self, alias: impl Into<String>, value: AggregationMetricValue) -> Self {
+        self.metrics.insert(alias.into(), value);
+        self
+    }
+
+    /// Sets the top-hits documents and returns the updated value.
+    pub fn hits(mut self, values: impl IntoIterator<Item = AggregationHit>) -> Self {
+        self.hits = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the top-hits documents and returns this value for further mutation.
+    pub fn set_hits(&mut self, values: impl IntoIterator<Item = AggregationHit>) -> &mut Self {
+        self.hits = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the top-hits documents.
+    pub fn get_hits(&self) -> &[AggregationHit] {
+        &self.hits
+    }
+
+    /// Appends a top-hits document and returns the updated value.
+    pub fn add_hit(mut self, value: AggregationHit) -> Self {
+        self.hits.push(value);
+        self
+    }
+
+    /// Sets the nested child buckets and returns the updated value.
+    pub fn sub_groups(mut self, values: impl IntoIterator<Item = AggregationBucket>) -> Self {
+        self.sub_groups = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the nested child buckets and returns this value for further mutation.
+    pub fn set_sub_groups(
+        &mut self,
+        values: impl IntoIterator<Item = AggregationBucket>,
+    ) -> &mut Self {
+        self.sub_groups = values.into_iter().collect();
+        self
+    }
+
+    /// Returns the nested child buckets.
+    pub fn get_sub_groups(&self) -> &[AggregationBucket] {
+        &self.sub_groups
+    }
+
+    /// Appends a nested child bucket and returns the updated value.
+    pub fn add_sub_group(mut self, value: AggregationBucket) -> Self {
+        self.sub_groups.push(value);
+        self
+    }
+
+    pub(crate) fn from_proto(value: schema::AggBucket) -> Result<Self> {
+        let key = value
+            .key
+            .into_iter()
+            .map(BucketKeyEntry::from_proto)
+            .collect::<Result<_>>()?;
+        let metrics = value
+            .metrics
+            .into_iter()
+            .map(|(alias, metric)| Ok((alias, AggregationMetricValue::from_proto(metric.value)?)))
+            .collect::<Result<_>>()?;
+        let hits = value
+            .hits
+            .into_iter()
+            .map(AggregationHit::from_proto)
+            .collect::<Result<_>>()?;
+        let sub_groups = value
+            .sub_groups
+            .into_iter()
+            .map(AggregationBucket::from_proto)
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            key,
+            count: value.count,
+            metrics,
+            hits,
+            sub_groups,
+        })
+    }
+}
+
+/// Groups a flat aggregation bucket list into per-query lists using `agg_topks`.
+///
+/// The server flattens buckets for all query vectors into one `repeated` list and records the
+/// number of top-level buckets per query in `agg_topks`. Both lists being empty means no
+/// aggregation is present. Otherwise a `MalformedResponse` is returned when `agg_topks` is
+/// missing for a multi-query response, when its length does not match `num_queries`, or when the
+/// counts are negative, overflow `usize`, or do not add up to the number of parsed buckets. Each
+/// query vector receives its own group, which may be empty when a query produced no buckets.
+pub(crate) fn group_aggregation_buckets(
+    buckets: Vec<schema::AggBucket>,
+    topks: Vec<i64>,
+    num_queries: i64,
+) -> Result<Vec<Vec<AggregationBucket>>> {
+    if buckets.is_empty() && topks.is_empty() {
+        return Ok(Vec::new());
+    }
+    let parsed: Vec<AggregationBucket> = buckets
+        .into_iter()
+        .map(AggregationBucket::from_proto)
+        .collect::<Result<_>>()?;
+    if topks.is_empty() {
+        if num_queries > 1 {
+            return Err(Error::MalformedResponse(
+                "aggregation buckets returned without agg_topks for a multi-query search".into(),
+            ));
+        }
+        return Ok(vec![parsed]);
+    }
+    let num_queries = usize::try_from(num_queries).map_err(|_| {
+        Error::MalformedResponse(format!(
+            "aggregation num_queries value {num_queries} does not fit usize"
+        ))
+    })?;
+    if topks.len() != num_queries {
+        return Err(Error::MalformedResponse(format!(
+            "aggregation agg_topks length {} does not match num_queries {num_queries}",
+            topks.len()
+        )));
+    }
+    let total = parsed.len();
+    let mut remaining = parsed;
+    let mut groups = Vec::with_capacity(topks.len());
+    for topk in topks {
+        if topk < 0 {
+            return Err(Error::MalformedResponse(format!(
+                "aggregation response contains a negative agg_topks value {topk}"
+            )));
+        }
+        let size = usize::try_from(topk).map_err(|_| {
+            Error::MalformedResponse(format!(
+                "aggregation agg_topks value {topk} does not fit usize"
+            ))
+        })?;
+        if size > remaining.len() {
+            return Err(Error::MalformedResponse(format!(
+                "aggregation bucket count mismatch: agg_topks sum exceeds {total} parsed buckets"
+            )));
+        }
+        groups.push(remaining.drain(..size).collect());
+    }
+    if !remaining.is_empty() {
+        return Err(Error::MalformedResponse(format!(
+            "aggregation bucket count mismatch: agg_topks sum={}, parsed={total}",
+            total - remaining.len()
+        )));
+    }
+    Ok(groups)
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // SearchResults
 ///////////////////////////////////////////////////////////////////////////////
 /// Search results for all query vectors, with one [`SingleResult`] per query vector.
@@ -2356,6 +2986,7 @@ fn result_json_kind(value: &Value) -> &'static str {
 pub struct SearchResults {
     pub(crate) results: Vec<SingleResult>,
     pub(crate) recalls: Vec<f32>,
+    pub(crate) agg_buckets: Vec<Vec<AggregationBucket>>,
 }
 
 impl SearchResults {
@@ -2364,6 +2995,7 @@ impl SearchResults {
         Self {
             results: Vec::new(),
             recalls: Vec::new(),
+            agg_buckets: Vec::new(),
         }
     }
 
@@ -2425,6 +3057,32 @@ impl SearchResults {
     /// Adds one add recall to the existing values.
     pub fn add_recall(mut self, value: f32) -> Self {
         self.recalls.push(value);
+        self
+    }
+
+    /// Sets the hierarchical aggregation buckets, grouped per query vector, and returns the
+    /// updated value.
+    pub fn agg_buckets(mut self, value: Vec<Vec<AggregationBucket>>) -> Self {
+        self.agg_buckets = value;
+        self
+    }
+
+    /// Sets the hierarchical aggregation buckets, grouped per query vector, and returns this value
+    /// for further mutation.
+    pub fn set_agg_buckets(&mut self, value: Vec<Vec<AggregationBucket>>) -> &mut Self {
+        self.agg_buckets = value;
+        self
+    }
+
+    /// Returns the hierarchical aggregation buckets, one inner list per query vector, when a
+    /// search aggregation was requested.
+    pub fn get_agg_buckets(&self) -> &[Vec<AggregationBucket>] {
+        &self.agg_buckets
+    }
+
+    /// Appends one query vector's aggregation buckets and returns the updated value.
+    pub fn add_agg_bucket(mut self, value: Vec<AggregationBucket>) -> Self {
+        self.agg_buckets.push(value);
         self
     }
 }
@@ -3598,5 +4256,314 @@ mod enum_conversion_tests {
 
         assert_eq!(lexical.r#type, common::HighlightType::Lexical as i32);
         assert_eq!(semantic.r#type, common::HighlightType::Semantic as i32);
+    }
+}
+
+#[cfg(test)]
+mod aggregation_decoding_tests {
+    use super::*;
+    use schema::{
+        agg_hit, agg_hit_field, bucket_key_entry, metric_value, AggBucket, AggHit, AggHitField,
+        BucketKeyEntry, MetricValue,
+    };
+
+    fn key(field_id: i64, field_name: &str, value: bucket_key_entry::Value) -> BucketKeyEntry {
+        BucketKeyEntry {
+            field_id,
+            field_name: field_name.to_owned(),
+            value: Some(value),
+        }
+    }
+
+    fn metrics(values: Vec<(String, MetricValue)>) -> HashMap<String, MetricValue> {
+        values.into_iter().collect()
+    }
+
+    fn metric(alias: &str, value: metric_value::Value) -> (String, MetricValue) {
+        (alias.to_owned(), MetricValue { value: Some(value) })
+    }
+
+    fn hit(pk: Option<agg_hit::Pk>, fields: Vec<AggHitField>) -> AggHit {
+        AggHit {
+            pk,
+            score: 0.5,
+            fields,
+        }
+    }
+
+    #[test]
+    fn aggregation_bucket_decodes_nested_structure() {
+        let proto = AggBucket {
+            key: vec![
+                key(
+                    1,
+                    "category",
+                    bucket_key_entry::Value::StringVal("tech".to_owned()),
+                ),
+                key(2, "year", bucket_key_entry::Value::IntVal(2026)),
+            ],
+            count: 42,
+            metrics: metrics(vec![
+                metric("total", metric_value::Value::DoubleVal(99.5)),
+                metric("min_rating", metric_value::Value::IntVal(4)),
+                metric("tag", metric_value::Value::StringVal("hot".to_owned())),
+            ]),
+            hits: vec![hit(
+                Some(agg_hit::Pk::IntPk(7)),
+                vec![AggHitField {
+                    field_id: 1,
+                    field_name: "title".to_owned(),
+                    value: Some(agg_hit_field::Value::StringVal("milvus".to_owned())),
+                }],
+            )],
+            sub_groups: vec![AggBucket {
+                key: vec![key(3, "sub", bucket_key_entry::Value::BoolVal(true))],
+                count: 1,
+                metrics: metrics(vec![metric("total", metric_value::Value::IntVal(1))]),
+                hits: vec![],
+                sub_groups: vec![],
+            }],
+        };
+
+        let bucket = AggregationBucket::from_proto(proto).expect("valid bucket");
+        assert_eq!(bucket.get_count(), 42);
+        assert_eq!(bucket.get_key().len(), 2);
+        assert_eq!(bucket.get_key()[0].get_field_name(), "category");
+        assert_eq!(
+            bucket.get_key()[0].get_value(),
+            &AggregationBucketValue::String("tech".to_owned())
+        );
+        assert_eq!(
+            bucket.get_key()[1].get_value(),
+            &AggregationBucketValue::Int(2026)
+        );
+        assert_eq!(
+            bucket.get_metrics().get("total"),
+            Some(&AggregationMetricValue::Double(99.5))
+        );
+        assert_eq!(
+            bucket.get_metrics().get("min_rating"),
+            Some(&AggregationMetricValue::Int(4))
+        );
+        assert_eq!(
+            bucket.get_metrics().get("tag"),
+            Some(&AggregationMetricValue::String("hot".to_owned()))
+        );
+        assert_eq!(bucket.get_hits().len(), 1);
+        assert_eq!(
+            bucket.get_hits()[0].get_pk(),
+            Some(&AggregationHitPk::Int(7))
+        );
+        assert_eq!(bucket.get_hits()[0].get_score(), 0.5);
+        assert_eq!(
+            bucket.get_hits()[0].get_fields()[0].get_value(),
+            &AggregationHitFieldValue::String("milvus".to_owned())
+        );
+        let sub = &bucket.get_sub_groups()[0];
+        assert_eq!(sub.get_count(), 1);
+        assert_eq!(
+            sub.get_key()[0].get_value(),
+            &AggregationBucketValue::Bool(true)
+        );
+    }
+
+    #[test]
+    fn aggregation_bucket_rejects_missing_key_value() {
+        let proto = AggBucket {
+            key: vec![BucketKeyEntry {
+                field_id: 1,
+                field_name: "category".to_owned(),
+                value: None,
+            }],
+            count: 1,
+            metrics: metrics(vec![]),
+            hits: vec![],
+            sub_groups: vec![],
+        };
+        let error =
+            AggregationBucket::from_proto(proto).expect_err("missing key value must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("bucket key"));
+    }
+
+    #[test]
+    fn empty_field_names_fall_back_to_field_id() {
+        let bucket = AggregationBucket::from_proto(AggBucket {
+            key: vec![key(
+                5,
+                "",
+                bucket_key_entry::Value::StringVal("x".to_owned()),
+            )],
+            count: 1,
+            metrics: metrics(vec![]),
+            hits: vec![hit(
+                Some(agg_hit::Pk::IntPk(7)),
+                vec![AggHitField {
+                    field_id: 9,
+                    field_name: String::new(),
+                    value: Some(agg_hit_field::Value::StringVal("v".to_owned())),
+                }],
+            )],
+            sub_groups: vec![],
+        })
+        .expect("valid bucket");
+
+        // Both the grouping key and hit fields substitute the numeric field id when the
+        // server omits the field name, mirroring pymilvus.
+        assert_eq!(bucket.get_key()[0].get_field_name(), "5");
+        assert_eq!(bucket.get_hits()[0].get_fields()[0].get_field_name(), "9");
+        assert_eq!(bucket.get_key()[0].get_field_id(), 5);
+        assert_eq!(bucket.get_hits()[0].get_fields()[0].get_field_id(), 9);
+    }
+
+    #[test]
+    fn aggregation_bucket_rejects_missing_metric_value() {
+        let proto = AggBucket {
+            key: vec![],
+            count: 1,
+            metrics: metrics(vec![("total".to_owned(), MetricValue { value: None })]),
+            hits: vec![],
+            sub_groups: vec![],
+        };
+        let error = AggregationBucket::from_proto(proto)
+            .expect_err("missing metric value must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("metric"));
+    }
+
+    #[test]
+    fn aggregation_bucket_rejects_missing_hit_field_value() {
+        let proto = AggBucket {
+            key: vec![],
+            count: 1,
+            metrics: metrics(vec![]),
+            hits: vec![hit(
+                Some(agg_hit::Pk::StrPk("doc".to_owned())),
+                vec![AggHitField {
+                    field_id: 1,
+                    field_name: "title".to_owned(),
+                    value: None,
+                }],
+            )],
+            sub_groups: vec![],
+        };
+        let error = AggregationBucket::from_proto(proto)
+            .expect_err("missing hit field value must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+    }
+
+    #[test]
+    fn search_results_exposes_grouped_aggregation_accessors() {
+        let bucket = || {
+            AggregationBucket::from_proto(AggBucket {
+                key: vec![],
+                count: 1,
+                metrics: metrics(vec![]),
+                hits: vec![],
+                sub_groups: vec![],
+            })
+            .expect("valid bucket")
+        };
+        let results =
+            SearchResults::new().agg_buckets(vec![vec![bucket(), bucket()], vec![bucket()]]);
+        assert_eq!(results.get_agg_buckets().len(), 2);
+        assert_eq!(results.get_agg_buckets()[0].len(), 2);
+        assert_eq!(results.get_agg_buckets()[1].len(), 1);
+    }
+
+    fn agg_bucket() -> schema::AggBucket {
+        schema::AggBucket {
+            key: vec![],
+            count: 1,
+            metrics: HashMap::new(),
+            hits: vec![],
+            sub_groups: vec![],
+        }
+    }
+
+    #[test]
+    fn groups_aggregation_buckets_per_query() {
+        let grouped = group_aggregation_buckets(
+            vec![agg_bucket(), agg_bucket(), agg_bucket()],
+            vec![2, 1],
+            2,
+        )
+        .expect("valid grouping");
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[0].len(), 2);
+        assert_eq!(grouped[1].len(), 1);
+        assert_eq!(grouped[0][0].get_count(), 1);
+    }
+
+    #[test]
+    fn grouping_recovers_single_query_without_topks() {
+        let grouped =
+            group_aggregation_buckets(vec![agg_bucket()], Vec::new(), 1).expect("nq==1 recovery");
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].len(), 1);
+    }
+
+    #[test]
+    fn grouping_rejects_missing_topks_for_multi_query() {
+        let error = group_aggregation_buckets(vec![agg_bucket()], Vec::new(), 2)
+            .expect_err("multi-query without agg_topks must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("agg_topks"));
+    }
+
+    #[test]
+    fn grouping_rejects_negative_topk() {
+        let error = group_aggregation_buckets(vec![agg_bucket()], vec![-1], 1)
+            .expect_err("negative agg_topks must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+    }
+
+    #[test]
+    fn grouping_rejects_count_mismatch() {
+        let error = group_aggregation_buckets(vec![agg_bucket(), agg_bucket()], vec![1], 1)
+            .expect_err("agg_topks sum below bucket count must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("mismatch"));
+
+        let error = group_aggregation_buckets(vec![agg_bucket()], vec![2], 1)
+            .expect_err("agg_topks sum above bucket count must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("mismatch"));
+    }
+
+    #[test]
+    fn grouping_builds_empty_groups_per_query() {
+        let grouped =
+            group_aggregation_buckets(Vec::new(), vec![0, 0], 2).expect("zero-bucket grouping");
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[0].len(), 0);
+        assert_eq!(grouped[1].len(), 0);
+    }
+
+    #[test]
+    fn grouping_treats_both_empty_as_no_aggregation() {
+        let grouped = group_aggregation_buckets(Vec::new(), Vec::new(), 2).expect("no aggregation");
+        assert_eq!(grouped.len(), 0);
+    }
+
+    #[test]
+    fn grouping_rejects_topks_arity_mismatch() {
+        let error = group_aggregation_buckets(vec![agg_bucket()], vec![1], 2)
+            .expect_err("agg_topks arity must match num_queries");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("num_queries"));
+
+        let error = group_aggregation_buckets(Vec::new(), vec![0], 2)
+            .expect_err("zero-bucket topks arity must match num_queries");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("num_queries"));
+    }
+
+    #[test]
+    fn grouping_rejects_zero_bucket_count_exceeding_queries() {
+        let error = group_aggregation_buckets(Vec::new(), vec![1], 1)
+            .expect_err("agg_topks exceeding buckets must be rejected");
+        assert!(matches!(error, Error::MalformedResponse(_)));
+        assert!(error.to_string().contains("mismatch"));
     }
 }

--- a/src/v2/types/function_chain.rs
+++ b/src/v2/types/function_chain.rs
@@ -1,0 +1,1590 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Function-chain types for search-time reranking and post-processing.
+//!
+//! Function chains compose ordered [`FunctionChainOp`] operations (for example `map`, `sort`,
+//! `limit`) into a [`FunctionChain`] executed by the server at a given [`FunctionChainStage`].
+//! Expressions are built with [`FunctionChainExpr`] using [`col`] references and typed
+//! [`FunctionParamValue`] parameters. The [`fn_`] module provides convenience constructors for
+//! the common server-side functions, mirroring pymilvus's `fn` module.
+//!
+//! ```
+//! use milvus::v2::prelude::*;
+//!
+//! let chain = FunctionChain::new()
+//!     .stage(FunctionChainStage::L2Rerank)
+//!     .name("fresh_popular_rerank")
+//!     .map(
+//!         "freshness",
+//!         fn_::decay(
+//!             col("published_at"),
+//!             "exp",
+//!             1700000000.0,
+//!             86400.0,
+//!             None,
+//!             None,
+//!         ),
+//!     )
+//!     .map(
+//!         "$score",
+//!         fn_::num_combine(
+//!             vec![col("$score"), col("freshness"), col("popularity")],
+//!             "weighted",
+//!             Some(vec![0.7, 0.2, 0.1]),
+//!         ),
+//!     )
+//!     .sort("$score", true, None)
+//!     .limit(10, 0);
+//! ```
+
+use crate::proto::schema;
+use crate::v2::error::{Error, Result};
+use std::collections::HashMap;
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionChainStage
+///////////////////////////////////////////////////////////////////////////////
+/// Execution stage where a function chain runs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FunctionChainStage {
+    #[default]
+    /// Represents the Unspecified case.
+    Unspecified,
+    /// Represents the Ingestion case.
+    Ingestion,
+    /// Represents the PreProcess case.
+    PreProcess,
+    /// Represents the L0Rerank case.
+    L0Rerank,
+    /// Represents the L1Rerank case.
+    L1Rerank,
+    /// Represents the L2Rerank case.
+    L2Rerank,
+    /// Represents the PostProcess case.
+    PostProcess,
+}
+
+impl FunctionChainStage {
+    pub(crate) fn into_proto(self) -> schema::FunctionChainStage {
+        match self {
+            Self::Unspecified => schema::FunctionChainStage::Unspecified,
+            Self::Ingestion => schema::FunctionChainStage::Ingestion,
+            Self::PreProcess => schema::FunctionChainStage::PreProcess,
+            Self::L0Rerank => schema::FunctionChainStage::L0Rerank,
+            Self::L1Rerank => schema::FunctionChainStage::L1Rerank,
+            Self::L2Rerank => schema::FunctionChainStage::L2Rerank,
+            Self::PostProcess => schema::FunctionChainStage::PostProcess,
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionParamValue
+///////////////////////////////////////////////////////////////////////////////
+/// Typed parameter value accepted by a function chain expression or operation.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum FunctionParamValue {
+    /// Represents a boolean value.
+    Bool(bool),
+    /// Represents an integer value.
+    Int(i64),
+    /// Represents a floating-point value.
+    Double(f64),
+    /// Represents a string value.
+    String(String),
+    /// Represents a bytes value.
+    Bytes(Vec<u8>),
+    /// Represents an array of values.
+    Array(Vec<FunctionParamValue>),
+    /// Represents a keyed object of values.
+    Object(HashMap<String, FunctionParamValue>),
+}
+
+impl FunctionParamValue {
+    /// Builds an array value from an iterator of values.
+    pub fn array(values: impl IntoIterator<Item = impl Into<FunctionParamValue>>) -> Self {
+        Self::Array(values.into_iter().map(Into::into).collect())
+    }
+
+    /// Builds an object value from an iterator of key/value pairs.
+    pub fn object(
+        fields: impl IntoIterator<Item = (String, impl Into<FunctionParamValue>)>,
+    ) -> Self {
+        Self::Object(
+            fields
+                .into_iter()
+                .map(|(key, value)| (key, value.into()))
+                .collect(),
+        )
+    }
+
+    pub(crate) fn into_proto(self) -> schema::FunctionParamValue {
+        use schema::function_param_value::Value;
+        schema::FunctionParamValue {
+            value: Some(match self {
+                Self::Bool(value) => Value::BoolValue(value),
+                Self::Int(value) => Value::Int64Value(value),
+                Self::Double(value) => Value::DoubleValue(value),
+                Self::String(value) => Value::StringValue(value),
+                Self::Bytes(value) => Value::BytesValue(value),
+                Self::Array(values) => Value::ArrayValue(schema::FunctionParamArray {
+                    values: values
+                        .into_iter()
+                        .map(FunctionParamValue::into_proto)
+                        .collect(),
+                }),
+                Self::Object(fields) => Value::ObjectValue(schema::FunctionParamObject {
+                    fields: fields
+                        .into_iter()
+                        .map(|(key, value)| (key, value.into_proto()))
+                        .collect(),
+                }),
+            }),
+        }
+    }
+}
+
+impl From<bool> for FunctionParamValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<i64> for FunctionParamValue {
+    fn from(value: i64) -> Self {
+        Self::Int(value)
+    }
+}
+
+impl From<i32> for FunctionParamValue {
+    fn from(value: i32) -> Self {
+        Self::Int(i64::from(value))
+    }
+}
+
+impl From<f64> for FunctionParamValue {
+    fn from(value: f64) -> Self {
+        Self::Double(value)
+    }
+}
+
+impl From<String> for FunctionParamValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for FunctionParamValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
+impl From<Vec<u8>> for FunctionParamValue {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+impl From<Vec<FunctionParamValue>> for FunctionParamValue {
+    fn from(value: Vec<FunctionParamValue>) -> Self {
+        Self::Array(value)
+    }
+}
+
+impl From<HashMap<String, FunctionParamValue>> for FunctionParamValue {
+    fn from(value: HashMap<String, FunctionParamValue>) -> Self {
+        Self::Object(value)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionChainArg
+///////////////////////////////////////////////////////////////////////////////
+/// Expression argument: either a collection-field/temporary reference or a literal value.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum FunctionChainArg {
+    /// A collection field, temporary variable, or system name (for example `"$score"`).
+    Column(String),
+    /// A literal argument value.
+    Literal(FunctionParamValue),
+}
+
+/// Creates a column-reference argument for a function chain expression.
+pub fn col(name: impl Into<String>) -> FunctionChainArg {
+    FunctionChainArg::Column(name.into())
+}
+
+impl FunctionChainArg {
+    pub(crate) fn into_proto(self) -> schema::FunctionChainExprArg {
+        use schema::function_chain_expr_arg::Arg;
+        schema::FunctionChainExprArg {
+            arg: Some(match self {
+                Self::Column(name) => Arg::Column(schema::FunctionChainColumnArg { name }),
+                Self::Literal(value) => Arg::Literal(value.into_proto()),
+            }),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionChainExpr
+///////////////////////////////////////////////////////////////////////////////
+/// A function invocation expression used by a function chain operation.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct FunctionChainExpr {
+    pub(crate) name: String,
+    pub(crate) args: Vec<FunctionChainArg>,
+    pub(crate) params: HashMap<String, FunctionParamValue>,
+}
+
+impl FunctionChainExpr {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            name: String::new(),
+            args: Vec::new(),
+            params: HashMap::new(),
+        }
+    }
+
+    /// Sets the expression name and returns the updated value.
+    pub fn name(mut self, value: impl Into<String>) -> Self {
+        self.name = value.into();
+        self
+    }
+
+    /// Sets the expression name and returns this value for further mutation.
+    pub fn set_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.name = value.into();
+        self
+    }
+
+    /// Sets the expression arguments and returns the updated value.
+    pub fn args(mut self, values: impl IntoIterator<Item = FunctionChainArg>) -> Self {
+        self.args = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the expression arguments and returns this value for further mutation.
+    pub fn set_args(&mut self, values: impl IntoIterator<Item = FunctionChainArg>) -> &mut Self {
+        self.args = values.into_iter().collect();
+        self
+    }
+
+    /// Appends a positional argument and returns the updated value.
+    pub fn add_arg(mut self, value: FunctionChainArg) -> Self {
+        self.args.push(value);
+        self
+    }
+
+    /// Sets the expression parameters and returns the updated value.
+    pub fn params(
+        mut self,
+        values: impl IntoIterator<Item = (String, FunctionParamValue)>,
+    ) -> Self {
+        self.params = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the expression parameters and returns this value for further mutation.
+    pub fn set_params(
+        &mut self,
+        values: impl IntoIterator<Item = (String, FunctionParamValue)>,
+    ) -> &mut Self {
+        self.params = values.into_iter().collect();
+        self
+    }
+
+    /// Adds a keyword-style parameter and returns the updated value.
+    pub fn add_param(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<FunctionParamValue>,
+    ) -> Self {
+        self.params.insert(key.into(), value.into());
+        self
+    }
+
+    /// Returns the expression name.
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the expression arguments.
+    pub fn get_args(&self) -> &[FunctionChainArg] {
+        &self.args
+    }
+
+    /// Returns the expression parameters.
+    pub fn get_params(&self) -> &HashMap<String, FunctionParamValue> {
+        &self.params
+    }
+
+    pub(crate) fn into_proto(self) -> schema::FunctionChainExpr {
+        schema::FunctionChainExpr {
+            name: self.name,
+            args: self
+                .args
+                .into_iter()
+                .map(FunctionChainArg::into_proto)
+                .collect(),
+            params: self
+                .params
+                .into_iter()
+                .map(|(key, value)| (key, value.into_proto()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionChainOp
+///////////////////////////////////////////////////////////////////////////////
+/// A single operation in a function chain pipeline.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct FunctionChainOp {
+    pub(crate) op: String,
+    pub(crate) expr: Option<FunctionChainExpr>,
+    pub(crate) inputs: Vec<String>,
+    pub(crate) outputs: Vec<String>,
+    pub(crate) params: HashMap<String, FunctionParamValue>,
+}
+
+impl FunctionChainOp {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            op: String::new(),
+            expr: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            params: HashMap::new(),
+        }
+    }
+
+    /// Sets the operation name and returns the updated value.
+    pub fn op(mut self, value: impl Into<String>) -> Self {
+        self.op = value.into();
+        self
+    }
+
+    /// Sets the operation name and returns this value for further mutation.
+    pub fn set_op(&mut self, value: impl Into<String>) -> &mut Self {
+        self.op = value.into();
+        self
+    }
+
+    /// Sets the attached expression and returns the updated value.
+    pub fn expr(mut self, value: FunctionChainExpr) -> Self {
+        self.expr = Some(value);
+        self
+    }
+
+    /// Sets the attached expression and returns this value for further mutation.
+    pub fn set_expr(&mut self, value: FunctionChainExpr) -> &mut Self {
+        self.expr = Some(value);
+        self
+    }
+
+    /// Sets the input names and returns the updated value.
+    pub fn inputs(mut self, values: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.inputs = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the input names and returns this value for further mutation.
+    pub fn set_inputs(&mut self, values: impl IntoIterator<Item = impl Into<String>>) -> &mut Self {
+        self.inputs = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Appends an input name and returns the updated value.
+    pub fn add_input(mut self, value: impl Into<String>) -> Self {
+        self.inputs.push(value.into());
+        self
+    }
+
+    /// Sets the output names and returns the updated value.
+    pub fn outputs(mut self, values: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.outputs = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the output names and returns this value for further mutation.
+    pub fn set_outputs(
+        &mut self,
+        values: impl IntoIterator<Item = impl Into<String>>,
+    ) -> &mut Self {
+        self.outputs = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Appends an output name and returns the updated value.
+    pub fn add_output(mut self, value: impl Into<String>) -> Self {
+        self.outputs.push(value.into());
+        self
+    }
+
+    /// Sets the operation parameters and returns the updated value.
+    pub fn params(
+        mut self,
+        values: impl IntoIterator<Item = (String, FunctionParamValue)>,
+    ) -> Self {
+        self.params = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the operation parameters and returns this value for further mutation.
+    pub fn set_params(
+        &mut self,
+        values: impl IntoIterator<Item = (String, FunctionParamValue)>,
+    ) -> &mut Self {
+        self.params = values.into_iter().collect();
+        self
+    }
+
+    /// Adds a parameter and returns the updated value.
+    pub fn add_param(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<FunctionParamValue>,
+    ) -> Self {
+        self.params.insert(key.into(), value.into());
+        self
+    }
+
+    /// Returns the operation name.
+    pub fn get_op(&self) -> &str {
+        &self.op
+    }
+
+    /// Returns the attached expression.
+    pub fn get_expr(&self) -> &Option<FunctionChainExpr> {
+        &self.expr
+    }
+
+    /// Returns the input names.
+    pub fn get_inputs(&self) -> &[String] {
+        &self.inputs
+    }
+
+    /// Returns the output names.
+    pub fn get_outputs(&self) -> &[String] {
+        &self.outputs
+    }
+
+    /// Returns the operation parameters.
+    pub fn get_params(&self) -> &HashMap<String, FunctionParamValue> {
+        &self.params
+    }
+
+    pub(crate) fn into_proto(self) -> schema::FunctionChainOp {
+        schema::FunctionChainOp {
+            op: self.op,
+            expr: self.expr.map(FunctionChainExpr::into_proto),
+            inputs: self.inputs,
+            outputs: self.outputs,
+            params: self
+                .params
+                .into_iter()
+                .map(|(key, value)| (key, value.into_proto()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FunctionChain
+///////////////////////////////////////////////////////////////////////////////
+/// An ordered rerank/refine plan executed by the server at a function chain stage.
+///
+/// Compose operations fluently with [`Self::map`], [`Self::sort`], [`Self::limit`], or attach any
+/// raw [`FunctionChainOp`] with [`Self::add_op`], then attach the chain to a search request. The
+/// stage must not remain [`FunctionChainStage::Unspecified`] and the chain cannot be combined with
+/// a search `ranker`.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct FunctionChain {
+    pub(crate) name: String,
+    pub(crate) stage: FunctionChainStage,
+    pub(crate) ops: Vec<FunctionChainOp>,
+}
+
+impl FunctionChain {
+    /// Creates a value initialized with its SDK defaults.
+    pub fn new() -> Self {
+        Self {
+            name: String::new(),
+            stage: FunctionChainStage::Unspecified,
+            ops: Vec::new(),
+        }
+    }
+
+    /// Sets the chain name and returns the updated value.
+    pub fn name(mut self, value: impl Into<String>) -> Self {
+        self.name = value.into();
+        self
+    }
+
+    /// Sets the chain name and returns this value for further mutation.
+    pub fn set_name(&mut self, value: impl Into<String>) -> &mut Self {
+        self.name = value.into();
+        self
+    }
+
+    /// Sets the execution stage and returns the updated value.
+    pub fn stage(mut self, value: FunctionChainStage) -> Self {
+        self.stage = value;
+        self
+    }
+
+    /// Sets the execution stage and returns this value for further mutation.
+    pub fn set_stage(&mut self, value: FunctionChainStage) -> &mut Self {
+        self.stage = value;
+        self
+    }
+
+    /// Sets the ordered operations and returns the updated value.
+    pub fn ops(mut self, values: impl IntoIterator<Item = FunctionChainOp>) -> Self {
+        self.ops = values.into_iter().collect();
+        self
+    }
+
+    /// Sets the ordered operations and returns this value for further mutation.
+    pub fn set_ops(&mut self, values: impl IntoIterator<Item = FunctionChainOp>) -> &mut Self {
+        self.ops = values.into_iter().collect();
+        self
+    }
+
+    /// Appends a raw [`FunctionChainOp`] and returns the updated value.
+    ///
+    /// Use this to attach operations that the fluent [`Self::map`], [`Self::sort`], and
+    /// [`Self::limit`] conveniences do not expose, such as `filter`, `merge`, or a
+    /// hand-built future operation. The operation is validated by [`Self::validate`]
+    /// together with every other operation in the chain.
+    pub fn add_op(mut self, op: FunctionChainOp) -> Self {
+        self.ops.push(op);
+        self
+    }
+
+    /// Appends a `map` operation that writes an expression result to an output column.
+    pub fn map(mut self, output: impl Into<String>, expr: FunctionChainExpr) -> Self {
+        self.ops.push(
+            FunctionChainOp::new()
+                .op("map")
+                .expr(expr)
+                .outputs([output.into()]),
+        );
+        self
+    }
+
+    /// Appends a `sort` operation by a column, optionally with a tie-break column.
+    pub fn sort(
+        mut self,
+        by: impl Into<String>,
+        desc: bool,
+        tie_break_col: Option<String>,
+    ) -> Self {
+        let column = by.into();
+        let mut inputs = vec![column.clone()];
+        let mut op = FunctionChainOp::new()
+            .op("sort")
+            .add_param("column", column)
+            .add_param("desc", desc);
+        if let Some(tie_break_col) = tie_break_col {
+            inputs.push(tie_break_col.clone());
+            op = op.add_param("tie_break_col", tie_break_col);
+        }
+        self.ops.push(op.inputs(inputs));
+        self
+    }
+
+    /// Appends a `limit` operation with an optional offset.
+    pub fn limit(mut self, limit: i64, offset: i64) -> Self {
+        self.ops.push(
+            FunctionChainOp::new()
+                .op("limit")
+                .add_param("limit", limit)
+                .add_param("offset", offset),
+        );
+        self
+    }
+
+    /// Returns the chain name.
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the execution stage.
+    pub fn get_stage(&self) -> FunctionChainStage {
+        self.stage
+    }
+
+    /// Returns the ordered operations.
+    pub fn get_ops(&self) -> &[FunctionChainOp] {
+        &self.ops
+    }
+
+    /// Validates that the chain can be attached to a search request.
+    pub fn validate(&self) -> Result<()> {
+        if self.stage == FunctionChainStage::Unspecified {
+            return Err(Error::validation(
+                "function_chains".into(),
+                "UNSPECIFIED function chain stage is not supported for search".into(),
+            ));
+        }
+        if self.ops.is_empty() {
+            return Err(Error::validation(
+                "function_chains".into(),
+                "function chain must contain at least one operation".into(),
+            ));
+        }
+        for op in &self.ops {
+            let op_name = op.get_op();
+            validate_param_keys(&op.params, "function chain operation")?;
+            if op_name.is_empty() {
+                return Err(Error::validation(
+                    "function_chains".into(),
+                    "operation name must not be empty".into(),
+                ));
+            }
+            if let Some(expr) = &op.expr {
+                Self::validate_expr(expr)?;
+            }
+            match op_name {
+                "map" => {
+                    if op.expr.is_none() {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "map operation must attach an expression".into(),
+                        ));
+                    }
+                    if op.outputs.is_empty() || op.outputs.iter().any(String::is_empty) {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "map operation must write to at least one non-empty output name".into(),
+                        ));
+                    }
+                }
+                "sort" => {
+                    if !op
+                        .inputs
+                        .first()
+                        .map(|column| !column.is_empty())
+                        .unwrap_or(false)
+                    {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "sort operation must specify a non-empty sort column".into(),
+                        ));
+                    }
+                }
+                "limit" => {
+                    match op.params.get("limit") {
+                        Some(FunctionParamValue::Int(limit)) if *limit > 0 => {}
+                        _ => {
+                            return Err(Error::validation(
+                                "function_chains".into(),
+                                "limit operation must specify a positive limit".into(),
+                            ));
+                        }
+                    }
+                    if let Some(FunctionParamValue::Int(offset)) = op.params.get("offset") {
+                        if *offset < 0 {
+                            return Err(Error::validation(
+                                "function_chains".into(),
+                                "limit operation must not use a negative offset".into(),
+                            ));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_expr(expr: &FunctionChainExpr) -> Result<()> {
+        if expr.get_name().is_empty() {
+            return Err(Error::validation(
+                "function_chains".into(),
+                "expression name must not be empty".into(),
+            ));
+        }
+        validate_param_keys(expr.get_params(), "function chain expression")?;
+        for arg in expr.get_args() {
+            if let FunctionChainArg::Column(name) = arg {
+                if name.is_empty() {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "column reference must not be empty".into(),
+                    ));
+                }
+            }
+        }
+        match expr.get_name() {
+            "num_combine" => {
+                let columns = expr.get_args();
+                if columns.len() < 2 {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "num_combine requires at least two columns".into(),
+                    ));
+                }
+                if columns
+                    .iter()
+                    .any(|arg| !matches!(arg, FunctionChainArg::Column(_)))
+                {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "num_combine arguments must be column references".into(),
+                    ));
+                }
+                let mode = match expr.get_params().get("mode") {
+                    Some(FunctionParamValue::String(mode)) => mode.as_str(),
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "num_combine must specify a mode".into(),
+                        ));
+                    }
+                };
+                if !matches!(
+                    mode,
+                    "multiply" | "sum" | "max" | "min" | "avg" | "weighted"
+                ) {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        format!("unsupported num_combine mode {mode}"),
+                    ));
+                }
+                match expr.get_params().get("weights") {
+                    Some(FunctionParamValue::Array(weights))
+                        if mode == "weighted"
+                            && weights.len() == columns.len()
+                            && weights.iter().all(|weight| {
+                                matches!(weight, FunctionParamValue::Double(value) if value.is_finite())
+                            }) => {}
+                    None if mode != "weighted" => {}
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "num_combine weighted mode requires finite numeric weights matching the column count"
+                                .into(),
+                        ));
+                    }
+                }
+            }
+            "decay" => {
+                let args = expr.get_args();
+                if args.len() != 1 || !matches!(args[0], FunctionChainArg::Column(_)) {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "decay requires a single column value".into(),
+                    ));
+                }
+                let function = match expr.get_params().get("function") {
+                    Some(FunctionParamValue::String(function)) => function.as_str(),
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "decay must specify a function".into(),
+                        ));
+                    }
+                };
+                if !matches!(function, "gauss" | "exp" | "linear") {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        format!("unsupported decay function {function}"),
+                    ));
+                }
+                for name in ["origin", "scale", "offset", "decay"] {
+                    match expr.get_params().get(name) {
+                        Some(FunctionParamValue::Double(value)) if value.is_finite() => {}
+                        Some(FunctionParamValue::Double(_)) => {
+                            return Err(Error::validation(
+                                "function_chains".into(),
+                                format!("decay {name} must be a finite number"),
+                            ));
+                        }
+                        Some(_) => {
+                            return Err(Error::validation(
+                                "function_chains".into(),
+                                format!("decay {name} must be numeric"),
+                            ));
+                        }
+                        None if name == "origin" || name == "scale" => {
+                            return Err(Error::validation(
+                                "function_chains".into(),
+                                format!("decay must specify {name}"),
+                            ));
+                        }
+                        None => {}
+                    }
+                }
+            }
+            "round_decimal" => {
+                let args = expr.get_args();
+                if args.len() != 1 || !matches!(args[0], FunctionChainArg::Column(_)) {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "round_decimal requires a single column value".into(),
+                    ));
+                }
+                match expr.get_params().get("decimal") {
+                    Some(FunctionParamValue::Int(decimal)) if (0..=6).contains(decimal) => {}
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "round_decimal decimal must be an integer in [0, 6]".into(),
+                        ));
+                    }
+                }
+            }
+            "xgboost" => {
+                let features = expr.get_args();
+                if features.is_empty()
+                    || features
+                        .iter()
+                        .any(|arg| !matches!(arg, FunctionChainArg::Column(_)))
+                {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "xgboost requires at least one feature column".into(),
+                    ));
+                }
+                match expr.get_params().get("model_resource") {
+                    Some(FunctionParamValue::String(resource)) if !resource.is_empty() => {}
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "xgboost model_resource must be a non-empty string".into(),
+                        ));
+                    }
+                }
+                match expr.get_params().get("output") {
+                    Some(FunctionParamValue::String(output))
+                        if matches!(output.as_str(), "default" | "raw") => {}
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "xgboost output must be either \"default\" or \"raw\"".into(),
+                        ));
+                    }
+                }
+            }
+            "rerank_model" => {
+                let args = expr.get_args();
+                if args.len() != 1 || !matches!(args[0], FunctionChainArg::Column(_)) {
+                    return Err(Error::validation(
+                        "function_chains".into(),
+                        "rerank_model requires a single column value".into(),
+                    ));
+                }
+                match expr.get_params().get("queries") {
+                    Some(FunctionParamValue::Array(queries))
+                        if !queries.is_empty()
+                            && queries.iter().all(|query| {
+                                matches!(
+                                    query,
+                                    FunctionParamValue::String(value) if !value.is_empty()
+                                )
+                            }) => {}
+                    _ => {
+                        return Err(Error::validation(
+                            "function_chains".into(),
+                            "rerank_model queries must be a non-empty list of non-empty strings"
+                                .into(),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(crate) fn into_proto(self) -> schema::FunctionChain {
+        schema::FunctionChain {
+            name: self.name,
+            stage: self.stage.into_proto() as i32,
+            ops: self
+                .ops
+                .into_iter()
+                .map(FunctionChainOp::into_proto)
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Rejects empty keys in a parameter map, recursing into array and object values.
+///
+/// Empty parameter names would serialize into the proto parameter maps and are rejected by
+/// pymilvus (`_copy_param_map`) and the Milvus server alike.
+fn validate_param_keys(params: &HashMap<String, FunctionParamValue>, context: &str) -> Result<()> {
+    for (key, value) in params {
+        if key.is_empty() {
+            return Err(Error::validation(
+                "function_chains".into(),
+                format!("{context} parameter names must not be empty"),
+            ));
+        }
+        validate_param_value_keys(value, context)?;
+    }
+    Ok(())
+}
+
+fn validate_param_value_keys(value: &FunctionParamValue, context: &str) -> Result<()> {
+    match value {
+        FunctionParamValue::Array(values) => {
+            for value in values {
+                validate_param_value_keys(value, context)?;
+            }
+        }
+        FunctionParamValue::Object(fields) => validate_param_keys(fields, context)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// fn_
+///////////////////////////////////////////////////////////////////////////////
+/// Convenience constructors for common server-side function chain expressions.
+pub mod fn_ {
+    use super::{FunctionChainArg, FunctionChainExpr};
+    use std::collections::HashMap;
+
+    /// Builds a numeric combination expression over two or more columns.
+    pub fn num_combine(
+        cols: Vec<FunctionChainArg>,
+        mode: &str,
+        weights: Option<Vec<f64>>,
+    ) -> FunctionChainExpr {
+        let mut expr = FunctionChainExpr::new().name("num_combine");
+        for column in cols {
+            expr = expr.add_arg(column);
+        }
+        expr = expr.add_param("mode", mode);
+        if let Some(weights) = weights {
+            expr = expr.add_param("weights", super::FunctionParamValue::array(weights));
+        }
+        expr
+    }
+
+    /// Builds a decay scoring expression for a numeric column.
+    pub fn decay(
+        value: FunctionChainArg,
+        function: &str,
+        origin: f64,
+        scale: f64,
+        offset: Option<f64>,
+        decay: Option<f64>,
+    ) -> FunctionChainExpr {
+        let mut expr = FunctionChainExpr::new()
+            .name("decay")
+            .add_arg(value)
+            .add_param("function", function)
+            .add_param("origin", origin)
+            .add_param("scale", scale);
+        if let Some(offset) = offset {
+            expr = expr.add_param("offset", offset);
+        }
+        if let Some(decay) = decay {
+            expr = expr.add_param("decay", decay);
+        }
+        expr
+    }
+
+    /// Builds an expression that rounds a numeric column to a fixed number of decimals.
+    pub fn round_decimal(value: FunctionChainArg, decimal: i64) -> FunctionChainExpr {
+        FunctionChainExpr::new()
+            .name("round_decimal")
+            .add_arg(value)
+            .add_param("decimal", decimal)
+    }
+
+    /// Builds an expression that scores feature columns with a server-side XGBoost model.
+    ///
+    /// `output` selects the prediction mode: `"default"` applies the model objective transform
+    /// when supported, and `"raw"` returns the raw margin. When `output` is `None`, `"default"`
+    /// is used, mirroring pymilvus.
+    pub fn xgboost(
+        features: Vec<FunctionChainArg>,
+        model_resource: &str,
+        output: Option<&str>,
+    ) -> FunctionChainExpr {
+        let mut expr = FunctionChainExpr::new()
+            .name("xgboost")
+            .add_param("model_resource", model_resource)
+            .add_param("output", output.unwrap_or("default"));
+        for feature in features {
+            expr = expr.add_arg(feature);
+        }
+        expr
+    }
+
+    /// Builds an expression that reranks a column with an external rerank model provider.
+    pub fn rerank_model(
+        value: FunctionChainArg,
+        queries: Vec<String>,
+        provider_params: HashMap<String, super::FunctionParamValue>,
+    ) -> FunctionChainExpr {
+        let mut expr = FunctionChainExpr::new()
+            .name("rerank_model")
+            .add_arg(value)
+            .add_param("queries", super::FunctionParamValue::array(queries));
+        for (key, value) in provider_params {
+            expr = expr.add_param(key, value);
+        }
+        expr
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test Cases
+///////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::{col, fn_, FunctionChain, FunctionChainStage};
+    use crate::proto::schema;
+
+    #[test]
+    fn function_chain_encodes_stage_and_ops() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .name("fresh_popular_rerank")
+            .map(
+                "freshness",
+                fn_::decay(
+                    col("published_at"),
+                    "exp",
+                    1700000000.0,
+                    86400.0,
+                    None,
+                    None,
+                ),
+            )
+            .map(
+                "$score",
+                fn_::num_combine(
+                    vec![col("$score"), col("freshness"), col("popularity")],
+                    "weighted",
+                    Some(vec![0.7, 0.2, 0.1]),
+                ),
+            )
+            .sort("$score", true, None)
+            .limit(10, 0);
+        chain.validate().expect("valid chain");
+
+        let proto = chain.into_proto();
+        assert_eq!(proto.name, "fresh_popular_rerank");
+        assert_eq!(proto.stage, schema::FunctionChainStage::L2Rerank as i32);
+        assert_eq!(proto.ops.len(), 4);
+
+        assert_eq!(proto.ops[0].op, "map");
+        assert_eq!(proto.ops[0].outputs, ["freshness"]);
+        let decay = proto.ops[0].expr.as_ref().expect("map expr");
+        assert_eq!(decay.name, "decay");
+        assert_eq!(decay.args.len(), 1);
+        assert!(matches!(
+            decay.args[0].arg,
+            Some(schema::function_chain_expr_arg::Arg::Column(_))
+        ));
+        assert_eq!(
+            decay.params.get("function").and_then(|v| v.value.as_ref()),
+            Some(&schema::function_param_value::Value::StringValue(
+                "exp".to_owned()
+            ))
+        );
+
+        assert_eq!(proto.ops[1].op, "map");
+        let combine = proto.ops[1].expr.as_ref().expect("combine expr");
+        assert_eq!(combine.name, "num_combine");
+        assert_eq!(combine.args.len(), 3);
+
+        assert_eq!(proto.ops[2].op, "sort");
+        assert_eq!(proto.ops[2].inputs, ["$score"]);
+        assert_eq!(
+            proto.ops[2]
+                .params
+                .get("desc")
+                .and_then(|v| v.value.as_ref()),
+            Some(&schema::function_param_value::Value::BoolValue(true))
+        );
+
+        assert_eq!(proto.ops[3].op, "limit");
+        assert_eq!(
+            proto.ops[3]
+                .params
+                .get("limit")
+                .and_then(|v| v.value.as_ref()),
+            Some(&schema::function_param_value::Value::Int64Value(10))
+        );
+    }
+
+    #[test]
+    fn function_chain_rejects_unspecified_stage() {
+        let chain = FunctionChain::new().map("out", fn_::round_decimal(col("$score"), 3));
+        let error = chain
+            .validate()
+            .expect_err("unspecified stage must be rejected");
+        assert!(error.to_string().contains("UNSPECIFIED"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_ops() {
+        let chain = FunctionChain::new().stage(FunctionChainStage::L2Rerank);
+        let error = chain
+            .validate()
+            .expect_err("chain without operations must be rejected");
+        assert!(error.to_string().contains("at least one operation"));
+    }
+
+    #[test]
+    fn function_chain_rejects_non_positive_limit() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .limit(0, 0);
+        let error = chain
+            .validate()
+            .expect_err("non-positive limit must be rejected");
+        assert!(error.to_string().contains("positive limit"));
+
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .limit(-1, 0);
+        assert!(chain.validate().is_err());
+    }
+
+    #[test]
+    fn function_chain_rejects_negative_offset() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .limit(10, -1);
+        let error = chain
+            .validate()
+            .expect_err("negative offset must be rejected");
+        assert!(error.to_string().contains("negative offset"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_sort_column() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .sort("", true, None);
+        let error = chain
+            .validate()
+            .expect_err("empty sort column must be rejected");
+        assert!(error.to_string().contains("sort"));
+    }
+
+    #[test]
+    fn function_chain_accepts_raw_sort_op_with_inputs_only() {
+        let op = super::FunctionChainOp::new()
+            .op("sort")
+            .inputs(["$score"])
+            .add_param("desc", true);
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .add_op(op);
+        chain
+            .validate()
+            .expect("sort column from inputs[0] is valid");
+    }
+
+    #[test]
+    fn function_chain_rejects_raw_sort_op_without_inputs() {
+        let op = super::FunctionChainOp::new()
+            .op("sort")
+            .add_param("desc", true);
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .add_op(op);
+        let error = chain
+            .validate()
+            .expect_err("sort without a column input must be rejected");
+        assert!(error.to_string().contains("sort"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_map_output() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map("", fn_::round_decimal(col("$score"), 3));
+        let error = chain
+            .validate()
+            .expect_err("empty map output must be rejected");
+        assert!(error.to_string().contains("map"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_operation_name() {
+        let mut chain = FunctionChain::new().stage(FunctionChainStage::L2Rerank);
+        chain.ops.push(super::FunctionChainOp::new().op(""));
+        let error = chain
+            .validate()
+            .expect_err("empty operation name must be rejected");
+        assert!(error.to_string().contains("operation name"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_expression_name() {
+        let op = super::FunctionChainOp::new()
+            .op("map")
+            .expr(super::FunctionChainExpr::new().name(""))
+            .outputs(["out"]);
+        let mut chain = FunctionChain::new().stage(FunctionChainStage::L2Rerank);
+        chain.ops.push(op);
+        let error = chain
+            .validate()
+            .expect_err("empty expression name must be rejected");
+        assert!(error.to_string().contains("expression name"));
+    }
+
+    #[test]
+    fn function_chain_rejects_map_without_expression() {
+        let op = super::FunctionChainOp::new().op("map").outputs(["out"]);
+        let mut chain = FunctionChain::new().stage(FunctionChainStage::L2Rerank);
+        chain.ops.push(op);
+        let error = chain
+            .validate()
+            .expect_err("map without expression must be rejected");
+        assert!(error.to_string().contains("expression"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_column_reference() {
+        let op = super::FunctionChainOp::new()
+            .op("map")
+            .expr(
+                super::FunctionChainExpr::new()
+                    .name("round_decimal")
+                    .add_arg(col("")),
+            )
+            .outputs(["out"]);
+        let mut chain = FunctionChain::new().stage(FunctionChainStage::L2Rerank);
+        chain.ops.push(op);
+        let error = chain
+            .validate()
+            .expect_err("empty column reference must be rejected");
+        assert!(error.to_string().contains("column reference"));
+    }
+
+    #[test]
+    fn function_chain_adds_raw_operation() {
+        let op = super::FunctionChainOp::new()
+            .op("map")
+            .expr(fn_::num_combine(
+                vec![col("$score"), col("freshness")],
+                "sum",
+                None,
+            ))
+            .outputs(["out"]);
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .name("manual")
+            .add_op(op);
+        chain.validate().expect("valid chain with a raw operation");
+
+        let proto = chain.into_proto();
+        assert_eq!(proto.ops.len(), 1);
+        assert_eq!(proto.ops[0].op, "map");
+        assert_eq!(proto.ops[0].outputs, ["out"]);
+    }
+
+    #[test]
+    fn function_chain_add_op_validates_expression() {
+        let op = super::FunctionChainOp::new()
+            .op("map")
+            .expr(fn_::num_combine(vec![col("$score")], "sum", None))
+            .outputs(["out"]);
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .add_op(op);
+        let error = chain
+            .validate()
+            .expect_err("single-column num_combine must be rejected");
+        assert!(error.to_string().contains("at least two columns"));
+    }
+
+    #[test]
+    fn function_chain_rejects_num_combine_with_one_column() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map("out", fn_::num_combine(vec![col("$score")], "sum", None));
+        let error = chain
+            .validate()
+            .expect_err("single-column num_combine must be rejected");
+        assert!(error.to_string().contains("at least two columns"));
+    }
+
+    #[test]
+    fn function_chain_rejects_num_combine_literal_arg() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::num_combine(
+                    vec![
+                        col("$score"),
+                        super::FunctionChainArg::Literal(super::FunctionParamValue::Double(1.0)),
+                    ],
+                    "sum",
+                    None,
+                ),
+            );
+        let error = chain
+            .validate()
+            .expect_err("literal num_combine argument must be rejected");
+        assert!(error.to_string().contains("column references"));
+    }
+
+    #[test]
+    fn function_chain_rejects_weighted_num_combine_without_weights() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::num_combine(vec![col("$score"), col("freshness")], "weighted", None),
+            );
+        let error = chain
+            .validate()
+            .expect_err("weighted num_combine without weights must be rejected");
+        assert!(error.to_string().contains("weights"));
+    }
+
+    #[test]
+    fn function_chain_rejects_mismatched_num_combine_weights() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::num_combine(
+                    vec![col("$score"), col("freshness")],
+                    "weighted",
+                    Some(vec![0.5]),
+                ),
+            );
+        let error = chain
+            .validate()
+            .expect_err("mismatched num_combine weights must be rejected");
+        assert!(error.to_string().contains("weights"));
+    }
+
+    #[test]
+    fn function_chain_rejects_non_finite_num_combine_weights() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .add_op(
+                super::FunctionChainOp::new()
+                    .op("map")
+                    .expr(
+                        super::FunctionChainExpr::new()
+                            .name("num_combine")
+                            .add_arg(col("$score"))
+                            .add_arg(col("popularity"))
+                            .add_param("mode", "weighted")
+                            .add_param(
+                                "weights",
+                                super::FunctionParamValue::array([f64::NAN, f64::INFINITY]),
+                            ),
+                    )
+                    .outputs(["out"]),
+            );
+        let error = chain
+            .validate()
+            .expect_err("non-finite num_combine weights must be rejected");
+        assert!(error.to_string().contains("weights"));
+    }
+
+    #[test]
+    fn function_chain_rejects_non_numeric_num_combine_weights() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .add_op(
+                super::FunctionChainOp::new()
+                    .op("map")
+                    .expr(
+                        super::FunctionChainExpr::new()
+                            .name("num_combine")
+                            .add_arg(col("$score"))
+                            .add_arg(col("popularity"))
+                            .add_param("mode", "weighted")
+                            .add_param("weights", super::FunctionParamValue::array(["0.5", "0.5"])),
+                    )
+                    .outputs(["out"]),
+            );
+        let error = chain
+            .validate()
+            .expect_err("non-numeric num_combine weights must be rejected");
+        assert!(error.to_string().contains("weights"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_param_key() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                super::FunctionChainExpr::new()
+                    .name("round_decimal")
+                    .add_arg(col("$score"))
+                    .add_param("", 3),
+            );
+        let error = chain
+            .validate()
+            .expect_err("empty parameter keys must be rejected");
+        assert!(error.to_string().contains("parameter names"));
+    }
+
+    #[test]
+    fn function_chain_rejects_empty_nested_object_key() {
+        let mut nested = std::collections::HashMap::new();
+        nested.insert(String::new(), super::FunctionParamValue::Double(1.0));
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                super::FunctionChainExpr::new()
+                    .name("round_decimal")
+                    .add_arg(col("$score"))
+                    .add_param("provider", super::FunctionParamValue::Object(nested)),
+            );
+        let error = chain
+            .validate()
+            .expect_err("empty nested object keys must be rejected");
+        assert!(error.to_string().contains("parameter names"));
+    }
+
+    #[test]
+    fn function_chain_rejects_unsupported_num_combine_mode() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::num_combine(vec![col("$score"), col("freshness")], "product", None),
+            );
+        let error = chain
+            .validate()
+            .expect_err("unsupported num_combine mode must be rejected");
+        assert!(error.to_string().contains("mode"));
+    }
+
+    #[test]
+    fn function_chain_rejects_unsupported_decay_function() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::decay(col("published_at"), "foo", 1.0, 1.0, None, None),
+            );
+        let error = chain
+            .validate()
+            .expect_err("unsupported decay function must be rejected");
+        assert!(error.to_string().contains("decay function"));
+    }
+
+    #[test]
+    fn function_chain_rejects_round_decimal_out_of_range() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map("out", fn_::round_decimal(col("$score"), 7));
+        let error = chain
+            .validate()
+            .expect_err("out-of-range round_decimal must be rejected");
+        assert!(error.to_string().contains("decimal"));
+    }
+
+    #[test]
+    fn function_chain_rejects_xgboost_without_features() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map("out", fn_::xgboost(vec![], "xgb_model", None));
+        let error = chain
+            .validate()
+            .expect_err("xgboost without features must be rejected");
+        assert!(error.to_string().contains("feature column"));
+    }
+
+    #[test]
+    fn function_chain_xgboost_defaults_output_to_default() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::xgboost(vec![col("price"), col("popularity")], "xgb_model", None),
+            );
+        chain.validate().expect("valid xgboost chain");
+
+        let proto = chain.into_proto();
+        let expr = proto.ops[0].expr.as_ref().expect("xgboost expr");
+        assert_eq!(
+            expr.params.get("output").and_then(|v| v.value.as_ref()),
+            Some(&schema::function_param_value::Value::StringValue(
+                "default".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn function_chain_rejects_rerank_model_without_queries() {
+        let chain = FunctionChain::new()
+            .stage(FunctionChainStage::L2Rerank)
+            .map(
+                "out",
+                fn_::rerank_model(col("text"), vec![], std::collections::HashMap::new()),
+            );
+        let error = chain
+            .validate()
+            .expect_err("rerank_model without queries must be rejected");
+        assert!(error.to_string().contains("queries"));
+    }
+
+    #[test]
+    fn function_param_value_encodes_nested_arrays_and_objects() {
+        let value = super::FunctionParamValue::object([
+            (
+                "mode".to_owned(),
+                super::FunctionParamValue::String("weighted".to_owned()),
+            ),
+            (
+                "weights".to_owned(),
+                super::FunctionParamValue::array([0.7_f64, 0.3_f64]),
+            ),
+        ]);
+        let proto = value.into_proto();
+        match proto.value {
+            Some(schema::function_param_value::Value::ObjectValue(object)) => {
+                assert_eq!(object.fields.len(), 2);
+                assert!(object.fields.contains_key("mode"));
+                assert!(object.fields.contains_key("weights"));
+            }
+            other => panic!("unexpected param value encoding: {other:?}"),
+        }
+    }
+}

--- a/src/v2/types/mod.rs
+++ b/src/v2/types/mod.rs
@@ -16,11 +16,13 @@
 
 //! Shared SDK-owned domain types used by the V2 client.
 
+mod aggregation;
 mod cdc;
 mod collection;
 mod common;
 mod dml;
 mod dql;
+mod function_chain;
 mod global_cluster;
 mod index;
 mod partition;
@@ -29,11 +31,13 @@ mod resource_group;
 mod snapshot;
 mod utility;
 
+pub use aggregation::*;
 pub use cdc::*;
 pub use collection::*;
 pub use common::*;
 pub use dml::*;
 pub use dql::*;
+pub use function_chain::*;
 pub(crate) use global_cluster::*;
 pub use index::*;
 pub use partition::*;


### PR DESCRIPTION
Support the new search-time function chain (rerank/refine plan) and hierarchical bucket search aggregation, aligned with the Milvus server `FunctionChain` proto (`schema.proto`) and mirroring pymilvus / milvus-sdk-java.

**Function chains** (`src/v2/types/function_chain.rs`)
- `FunctionChainStage`, `FunctionParamValue`, `FunctionChainArg`/`col()`, `FunctionChainExpr`, `FunctionChainOp`, `FunctionChain`
- Builder API: `FunctionChain::new().stage(..).name(..).map(..).sort(..).limit(..)` plus the `fn_` module (`decay`, `num_combine`, `round_decimal`, `xgboost`, `rerank_model`)
- `SearchRequestBuilder::function_chains(..)` / `add_function_chain(..)`; validation rejects `function_chains` combined with `rerank` and requires a non-`Unspecified` stage

**Search aggregation** (`src/v2/types/aggregation.rs`)
- `SearchAggregation`, `MetricOp`, `MetricSpec`, `SortDirection`, `SortSpec`, `OrderSpec`, `TopHitsSpec`; recursively nestable via `sub_aggregation`
- `SearchRequestBuilder::search_aggregation(..)`; mutually exclusive with `group_by_field`
- Response side: `SearchResults::get_agg_buckets()` / `get_agg_topks()` with typed `AggregationBucket`, `BucketKeyEntry`, `AggregationHit` parsing

Verified locally: `cargo check`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious`, `python3 scripts/check_v2_api.py`, `cargo doc --no-deps` (`-D warnings`), `cargo test --doc`, `cargo test --test v2_ut`.