### PR TITLE
Align compact, list_indexes, and round_decimal with pymilvus

### DIFF
--- a/src/v2/client/index.rs
+++ b/src/v2/client/index.rs
@@ -75,9 +75,10 @@ impl ClientV2 {
         request: request::index::ListIndexesRequest,
     ) -> Result<response::index::ListIndexesResponse> {
         let database = self.current_database();
+        let field_name = request.field_name.clone();
         let response = rpc_with_retry!(self, get_index_statistics, request.into_proto(&database))?;
         status_to_result(&response.status)?;
-        response::index::ListIndexesResponse::from_proto(response)
+        response::index::ListIndexesResponse::from_proto(response, &field_name)
     }
 
     /// Updates mutable properties of an existing index.

--- a/src/v2/client/rbac.rs
+++ b/src/v2/client/rbac.rs
@@ -138,12 +138,21 @@ impl ClientV2 {
         &self,
         request: request::rbac::GrantPrivilegeRequest,
     ) -> Result<()> {
-        let status = status_rpc_with_retry!(
-            NonIdempotent,
-            self,
-            operate_privilege_v2,
-            request.into_proto()
-        )?;
+        let status = if request.is_v1() {
+            status_rpc_with_retry!(
+                NonIdempotent,
+                self,
+                operate_privilege,
+                request.into_proto_v1()
+            )?
+        } else {
+            status_rpc_with_retry!(
+                NonIdempotent,
+                self,
+                operate_privilege_v2,
+                request.into_proto_v2()
+            )?
+        };
         self.status(status)
     }
 
@@ -152,12 +161,21 @@ impl ClientV2 {
         &self,
         request: request::rbac::RevokePrivilegeRequest,
     ) -> Result<()> {
-        let status = status_rpc_with_retry!(
-            NonIdempotent,
-            self,
-            operate_privilege_v2,
-            request.into_proto()
-        )?;
+        let status = if request.is_v1() {
+            status_rpc_with_retry!(
+                NonIdempotent,
+                self,
+                operate_privilege,
+                request.into_proto_v1()
+            )?
+        } else {
+            status_rpc_with_retry!(
+                NonIdempotent,
+                self,
+                operate_privilege_v2,
+                request.into_proto_v2()
+            )?
+        };
         self.status(status)
     }
 

--- a/src/v2/client/utility.rs
+++ b/src/v2/client/utility.rs
@@ -373,6 +373,7 @@ impl ClientV2 {
                     collection_name: collection.clone(),
                     index_name: String::new(),
                     timestamp: 0,
+                    field_name: String::new(),
                 })
                 .await?;
             response

--- a/src/v2/request/dql.rs
+++ b/src/v2/request/dql.rs
@@ -1597,10 +1597,10 @@ impl HybridSearchRequestBuilder {
         non_negative_i64("offset", self.value.offset)?;
         positive_i64("group_size", self.value.group_size)?;
         validate_search_extra_params(&self.value.extra_params)?;
-        if self.value.round_decimal < -1 {
+        if !(-1..=6).contains(&self.value.round_decimal) {
             return Err(Error::validation(
                 "round_decimal".into(),
-                "must be -1 or greater".into(),
+                "must be in -1..=6".into(),
             ));
         }
         Ok(self.value)
@@ -1843,10 +1843,10 @@ fn validate_search_request(value: &SearchRequest) -> Result<()> {
     positive_i64("limit", value.limit)?;
     non_negative_i64("offset", value.offset)?;
     positive_i64("group_size", value.group_size)?;
-    if value.round_decimal < -1 {
+    if !(-1..=6).contains(&value.round_decimal) {
         return Err(Error::validation(
             "round_decimal".into(),
-            "must be -1 or greater".into(),
+            "must be in -1..=6".into(),
         ));
     }
     validate_search_extra_params(&value.extra_params)?;
@@ -2228,6 +2228,34 @@ mod search_request_tests {
             result,
             Err(crate::v2::error::Error::Validation(error)) if error.parameter() == "ids"
         ));
+    }
+
+    #[test]
+    fn search_rejects_round_decimal_outside_of_legal_range() {
+        let search = || {
+            SearchRequest::builder()
+                .collection_name("books")
+                .vector_field("vector")
+                .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+                .limit(3)
+        };
+        let hybrid = || {
+            let sub_request = SubSearchRequest::builder()
+                .vector_field("vector")
+                .vectors(SearchVectors::Float(vec![vec![0.1, 0.2]]))
+                .limit(3)
+                .build()
+                .expect("valid sub search request");
+            HybridSearchRequest::builder()
+                .collection_name("books")
+                .sub_requests(vec![sub_request])
+        };
+
+        assert!(search().round_decimal(7).build().is_err());
+        assert!(search().round_decimal(-2).build().is_err());
+        assert!(search().round_decimal(6).build().is_ok());
+        assert!(hybrid().round_decimal(7).build().is_err());
+        assert!(hybrid().round_decimal(6).build().is_ok());
     }
 
     #[test]
@@ -2851,7 +2879,7 @@ mod builder_value_tests {
         let output_fields = vec!["output_fields-value".to_owned()];
         let limit = 7;
         let offset = 7;
-        let round_decimal = 7;
+        let round_decimal = 6;
         let ignore_growing = true;
         let group_by_field = "group_by_field-value".to_owned();
         let group_size = 7;
@@ -3049,7 +3077,7 @@ mod builder_value_tests {
             .function_type(crate::v2::FunctionType::Bm25);
         let limit = 7;
         let offset = 7;
-        let round_decimal = 7;
+        let round_decimal = 6;
         let ignore_growing = true;
         let extra_params = HashMap::from([("key-value".to_owned(), "value-value".to_owned())]);
         let group_by_field = "group_by_field-value".to_owned();

--- a/src/v2/request/index.rs
+++ b/src/v2/request/index.rs
@@ -303,6 +303,7 @@ pub struct ListIndexesRequest {
     pub(crate) collection_name: String,
     pub(crate) index_name: String,
     pub(crate) timestamp: u64,
+    pub(crate) field_name: String,
 }
 
 impl ListIndexesRequest {
@@ -312,6 +313,7 @@ impl ListIndexesRequest {
             collection_name: Default::default(),
             index_name: Default::default(),
             timestamp: Default::default(),
+            field_name: Default::default(),
         }
     }
 
@@ -345,6 +347,11 @@ impl ListIndexesRequest {
     /// Returns the timestamp.
     pub fn timestamp(&self) -> u64 {
         self.timestamp
+    }
+
+    /// Returns the field name filter.
+    pub fn field_name(&self) -> &str {
+        &self.field_name
     }
 
     pub(crate) fn into_proto(self, db: &str) -> milvus::GetIndexStatisticsRequest {
@@ -389,6 +396,12 @@ impl ListIndexesRequestBuilder {
     /// Sets the timestamp and returns the updated value.
     pub fn timestamp(mut self, value: u64) -> Self {
         self.value.timestamp = value;
+        self
+    }
+
+    /// Sets the field name filter and returns the updated value.
+    pub fn field_name(mut self, value: impl Into<String>) -> Self {
+        self.value.field_name = value.into();
         self
     }
 
@@ -946,11 +959,13 @@ mod builder_value_tests {
         let expected_collection_name: String = String::new();
         let expected_index_name: String = String::new();
         let expected_timestamp: u64 = 0;
+        let expected_field_name: String = String::new();
 
         assert_eq!(value.database_name().to_owned(), expected_database_name);
         assert_eq!(value.collection_name().to_owned(), expected_collection_name);
         assert_eq!(value.index_name().to_owned(), expected_index_name);
         assert_eq!(value.timestamp().to_owned(), expected_timestamp);
+        assert_eq!(value.field_name().to_owned(), expected_field_name);
     }
 
     #[test]
@@ -959,11 +974,13 @@ mod builder_value_tests {
         let collection_name = "collection_name-value".to_owned();
         let index_name = "index_name-value".to_owned();
         let timestamp = 7;
+        let field_name = "field_name-value".to_owned();
         let value = ListIndexesRequest::builder()
             .database_name(database_name.clone())
             .collection_name(collection_name.clone())
             .index_name(index_name.clone())
             .timestamp(timestamp.clone())
+            .field_name(field_name.clone())
             .build()
             .expect("valid request");
 
@@ -971,6 +988,7 @@ mod builder_value_tests {
         assert_eq!(value.collection_name().to_owned(), collection_name);
         assert_eq!(value.index_name().to_owned(), index_name);
         assert_eq!(value.timestamp().to_owned(), timestamp);
+        assert_eq!(value.field_name().to_owned(), field_name);
     }
 
     #[test]

--- a/src/v2/request/rbac.rs
+++ b/src/v2/request/rbac.rs
@@ -1048,6 +1048,14 @@ impl DescribeUserRequestBuilder {
 // GrantPrivilegeRequest
 ///////////////////////////////////////////////////////////////////////////////
 /// Parameters for the ClientV2 grant_privilege operation.
+///
+/// Grants a privilege to a role. Two forms are supported:
+///
+/// - The default V2 form targets a collection: set `collection_name`.
+/// - The V1 object-scoped form targets an arbitrary object identified by
+///   `object_type` (e.g. `Global`, `Database`, `Collection`, `User`) and
+///   `object_name`. When `object_type` is set, the V1 `OperatePrivilege` RPC is
+///   used and `collection_name` is ignored.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct GrantPrivilegeRequest {
@@ -1055,6 +1063,8 @@ pub struct GrantPrivilegeRequest {
     pub(crate) database_name: String,
     pub(crate) collection_name: String,
     pub(crate) privilege: String,
+    pub(crate) object_type: Option<String>,
+    pub(crate) object_name: Option<String>,
 }
 
 impl GrantPrivilegeRequest {
@@ -1064,6 +1074,8 @@ impl GrantPrivilegeRequest {
             database_name: Default::default(),
             collection_name: Default::default(),
             privilege: Default::default(),
+            object_type: Default::default(),
+            object_name: Default::default(),
         }
     }
 
@@ -1099,7 +1111,47 @@ impl GrantPrivilegeRequest {
         &self.privilege
     }
 
-    pub(crate) fn into_proto(self) -> milvus::OperatePrivilegeV2Request {
+    /// Returns the V1 object type, e.g. `Global`, `Database`, `Collection`, `User`.
+    pub fn object_type(&self) -> Option<&str> {
+        self.object_type.as_deref()
+    }
+
+    /// Returns the V1 object name.
+    pub fn object_name(&self) -> Option<&str> {
+        self.object_name.as_deref()
+    }
+
+    /// Returns whether this request uses the V1 object-scoped privilege form.
+    pub(crate) fn is_v1(&self) -> bool {
+        self.object_type.is_some()
+    }
+
+    pub(crate) fn into_proto_v1(self) -> milvus::OperatePrivilegeRequest {
+        milvus::OperatePrivilegeRequest {
+            base: None,
+            entity: Some(milvus::GrantEntity {
+                role: Some(milvus::RoleEntity {
+                    name: self.role_name,
+                    description: String::new(),
+                }),
+                object: Some(milvus::ObjectEntity {
+                    name: self.object_type.unwrap_or_default(),
+                }),
+                object_name: self.object_name.unwrap_or_default(),
+                grantor: Some(milvus::GrantorEntity {
+                    user: None,
+                    privilege: Some(milvus::PrivilegeEntity {
+                        name: self.privilege,
+                    }),
+                }),
+                db_name: self.database_name,
+            }),
+            r#type: milvus::OperatePrivilegeType::Grant as i32,
+            version: String::new(),
+        }
+    }
+
+    pub(crate) fn into_proto_v2(self) -> milvus::OperatePrivilegeV2Request {
         milvus::OperatePrivilegeV2Request {
             base: None,
             role: Some(milvus::RoleEntity {
@@ -1153,14 +1205,40 @@ impl GrantPrivilegeRequestBuilder {
         self
     }
 
+    /// Sets the V1 object type (e.g. `Global`, `Database`, `Collection`, `User`)
+    /// and returns the updated value.
+    pub fn object_type(mut self, value: impl Into<String>) -> Self {
+        self.value.object_type = Some(value.into());
+        self
+    }
+
+    /// Sets the V1 object name and returns the updated value.
+    pub fn object_name(mut self, value: impl Into<String>) -> Self {
+        self.value.object_name = Some(value.into());
+        self
+    }
+
     /// Validates the configured values and builds the request.
     pub fn build(self) -> Result<GrantPrivilegeRequest> {
-        validate_privilege(
-            &self.value.role_name,
-            &self.value.database_name,
-            &self.value.collection_name,
-            &self.value.privilege,
-        )?;
+        if self.value.object_type.is_some() || self.value.object_name.is_some() {
+            required("role_name", &self.value.role_name)?;
+            required(
+                "object_type",
+                self.value.object_type.as_deref().unwrap_or_default(),
+            )?;
+            required(
+                "object_name",
+                self.value.object_name.as_deref().unwrap_or_default(),
+            )?;
+            required("privilege", &self.value.privilege)?;
+        } else {
+            validate_privilege(
+                &self.value.role_name,
+                &self.value.database_name,
+                &self.value.collection_name,
+                &self.value.privilege,
+            )?;
+        }
         Ok(self.value)
     }
 }
@@ -1169,6 +1247,14 @@ impl GrantPrivilegeRequestBuilder {
 // RevokePrivilegeRequest
 ///////////////////////////////////////////////////////////////////////////////
 /// Parameters for the ClientV2 revoke_privilege operation.
+///
+/// Revokes a privilege from a role. Two forms are supported:
+///
+/// - The default V2 form targets a collection: set `collection_name`.
+/// - The V1 object-scoped form targets an arbitrary object identified by
+///   `object_type` (e.g. `Global`, `Database`, `Collection`, `User`) and
+///   `object_name`. When `object_type` is set, the V1 `OperatePrivilege` RPC is
+///   used and `collection_name` is ignored.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct RevokePrivilegeRequest {
@@ -1176,6 +1262,8 @@ pub struct RevokePrivilegeRequest {
     pub(crate) database_name: String,
     pub(crate) collection_name: String,
     pub(crate) privilege: String,
+    pub(crate) object_type: Option<String>,
+    pub(crate) object_name: Option<String>,
 }
 
 impl RevokePrivilegeRequest {
@@ -1185,6 +1273,8 @@ impl RevokePrivilegeRequest {
             database_name: Default::default(),
             collection_name: Default::default(),
             privilege: Default::default(),
+            object_type: Default::default(),
+            object_name: Default::default(),
         }
     }
 
@@ -1220,7 +1310,47 @@ impl RevokePrivilegeRequest {
         &self.privilege
     }
 
-    pub(crate) fn into_proto(self) -> milvus::OperatePrivilegeV2Request {
+    /// Returns the V1 object type, e.g. `Global`, `Database`, `Collection`, `User`.
+    pub fn object_type(&self) -> Option<&str> {
+        self.object_type.as_deref()
+    }
+
+    /// Returns the V1 object name.
+    pub fn object_name(&self) -> Option<&str> {
+        self.object_name.as_deref()
+    }
+
+    /// Returns whether this request uses the V1 object-scoped privilege form.
+    pub(crate) fn is_v1(&self) -> bool {
+        self.object_type.is_some()
+    }
+
+    pub(crate) fn into_proto_v1(self) -> milvus::OperatePrivilegeRequest {
+        milvus::OperatePrivilegeRequest {
+            base: None,
+            entity: Some(milvus::GrantEntity {
+                role: Some(milvus::RoleEntity {
+                    name: self.role_name,
+                    description: String::new(),
+                }),
+                object: Some(milvus::ObjectEntity {
+                    name: self.object_type.unwrap_or_default(),
+                }),
+                object_name: self.object_name.unwrap_or_default(),
+                grantor: Some(milvus::GrantorEntity {
+                    user: None,
+                    privilege: Some(milvus::PrivilegeEntity {
+                        name: self.privilege,
+                    }),
+                }),
+                db_name: self.database_name,
+            }),
+            r#type: milvus::OperatePrivilegeType::Revoke as i32,
+            version: String::new(),
+        }
+    }
+
+    pub(crate) fn into_proto_v2(self) -> milvus::OperatePrivilegeV2Request {
         milvus::OperatePrivilegeV2Request {
             base: None,
             role: Some(milvus::RoleEntity {
@@ -1274,14 +1404,40 @@ impl RevokePrivilegeRequestBuilder {
         self
     }
 
+    /// Sets the V1 object type (e.g. `Global`, `Database`, `Collection`, `User`)
+    /// and returns the updated value.
+    pub fn object_type(mut self, value: impl Into<String>) -> Self {
+        self.value.object_type = Some(value.into());
+        self
+    }
+
+    /// Sets the V1 object name and returns the updated value.
+    pub fn object_name(mut self, value: impl Into<String>) -> Self {
+        self.value.object_name = Some(value.into());
+        self
+    }
+
     /// Validates the configured values and builds the request.
     pub fn build(self) -> Result<RevokePrivilegeRequest> {
-        validate_privilege(
-            &self.value.role_name,
-            &self.value.database_name,
-            &self.value.collection_name,
-            &self.value.privilege,
-        )?;
+        if self.value.object_type.is_some() || self.value.object_name.is_some() {
+            required("role_name", &self.value.role_name)?;
+            required(
+                "object_type",
+                self.value.object_type.as_deref().unwrap_or_default(),
+            )?;
+            required(
+                "object_name",
+                self.value.object_name.as_deref().unwrap_or_default(),
+            )?;
+            required("privilege", &self.value.privilege)?;
+        } else {
+            validate_privilege(
+                &self.value.role_name,
+                &self.value.database_name,
+                &self.value.collection_name,
+                &self.value.privilege,
+            )?;
+        }
         Ok(self.value)
     }
 }
@@ -1830,7 +1986,7 @@ mod dedicated_operation_tests {
             .privilege("Search")
             .build()
             .expect("valid request")
-            .into_proto();
+            .into_proto_v2();
         assert_eq!(grant.r#type, milvus::OperatePrivilegeType::Grant as i32);
         assert_eq!(grant.db_name, "catalog");
         assert_eq!(grant.collection_name, "books");
@@ -1842,8 +1998,63 @@ mod dedicated_operation_tests {
             .privilege("Search")
             .build()
             .expect("valid request")
-            .into_proto();
+            .into_proto_v2();
         assert_eq!(revoke.r#type, milvus::OperatePrivilegeType::Revoke as i32);
+    }
+
+    #[test]
+    fn privilege_requests_encode_v1_object_scoped_surface() {
+        let grant = GrantPrivilegeRequest::builder()
+            .role_name("analyst")
+            .database_name("catalog")
+            .object_type("Global")
+            .object_name("*")
+            .privilege("Search")
+            .build()
+            .expect("valid request");
+        assert!(grant.is_v1());
+        assert_eq!(grant.object_type(), Some("Global"));
+        assert_eq!(grant.object_name(), Some("*"));
+        let grant_proto = grant.into_proto_v1();
+        assert_eq!(
+            grant_proto.r#type,
+            milvus::OperatePrivilegeType::Grant as i32
+        );
+        let entity = grant_proto.entity.expect("v1 entity present");
+        assert_eq!(entity.object.map(|o| o.name), Some("Global".into()));
+        assert_eq!(entity.object_name, "*");
+        assert_eq!(entity.db_name, "catalog");
+
+        let revoke = RevokePrivilegeRequest::builder()
+            .role_name("analyst")
+            .database_name("catalog")
+            .object_type("Collection")
+            .object_name("books")
+            .privilege("Search")
+            .build()
+            .expect("valid request");
+        assert!(revoke.is_v1());
+        let revoke_proto = revoke.into_proto_v1();
+        assert_eq!(
+            revoke_proto.r#type,
+            milvus::OperatePrivilegeType::Revoke as i32
+        );
+    }
+
+    #[test]
+    fn privilege_requests_reject_incomplete_v1_object_scoped_surface() {
+        assert!(GrantPrivilegeRequest::builder()
+            .role_name("analyst")
+            .object_type("Global")
+            .privilege("Search")
+            .build()
+            .is_err());
+        assert!(RevokePrivilegeRequest::builder()
+            .role_name("analyst")
+            .object_name("books")
+            .privilege("Search")
+            .build()
+            .is_err());
     }
 
     #[test]

--- a/src/v2/request/utility.rs
+++ b/src/v2/request/utility.rs
@@ -19,7 +19,10 @@
 use crate::proto::milvus;
 use crate::v2::error::{Error, Result};
 use crate::v2::request::validation::{non_empty_strings, positive_i64, required, required_slice};
+use crate::v2::types::TargetSizeUnit;
 use std::collections::HashMap;
+
+const BYTES_PER_MB: i64 = 1024 * 1024;
 
 ///////////////////////////////////////////////////////////////////////////////
 // GetServerVersionRequest
@@ -578,8 +581,10 @@ impl ListQuerySegmentsRequestBuilder {
 pub struct CompactRequest {
     pub(crate) database_name: Option<String>,
     pub(crate) collection_name: String,
-    pub(crate) target_size: i64,
+    pub(crate) target_size: Option<i64>,
     pub(crate) clustering_compaction: bool,
+    pub(crate) l0_compaction: bool,
+    pub(crate) target_size_unit: TargetSizeUnit,
 }
 
 impl CompactRequest {
@@ -589,6 +594,8 @@ impl CompactRequest {
             collection_name: Default::default(),
             target_size: Default::default(),
             clustering_compaction: Default::default(),
+            l0_compaction: Default::default(),
+            target_size_unit: Default::default(),
         }
     }
 
@@ -614,8 +621,8 @@ impl CompactRequest {
         &self.collection_name
     }
 
-    /// Returns the target size.
-    pub fn target_size(&self) -> i64 {
+    /// Returns the target size in megabytes. `None` means that the server uses its default target size.
+    pub fn target_size(&self) -> Option<i64> {
         self.target_size
     }
 
@@ -624,12 +631,26 @@ impl CompactRequest {
         self.clustering_compaction
     }
 
+    /// Returns whether L0 compaction.
+    pub fn is_l0_compaction(&self) -> bool {
+        self.l0_compaction
+    }
+
+    /// Returns the unit used to interpret the target size.
+    ///
+    /// The stored target size is always normalized to megabytes, so a built
+    /// request always reports the megabyte unit.
+    pub fn target_size_unit(&self) -> TargetSizeUnit {
+        self.target_size_unit
+    }
+
     pub(crate) fn into_proto(self, default_db: &str) -> milvus::ManualCompactionRequest {
         let mut value = milvus::ManualCompactionRequest::default();
         value.db_name = self.database_name.unwrap_or_else(|| default_db.to_owned());
         value.collection_name = self.collection_name;
-        value.target_size = self.target_size;
+        value.target_size = self.target_size.unwrap_or_default();
         value.major_compaction = self.clustering_compaction;
+        value.l0_compaction = self.l0_compaction;
         value
     }
 }
@@ -658,7 +679,7 @@ impl CompactRequestBuilder {
 
     /// Sets the target size and returns the updated value.
     pub fn target_size(mut self, value: i64) -> Self {
-        self.value.target_size = value;
+        self.value.target_size = Some(value);
         self
     }
 
@@ -668,20 +689,66 @@ impl CompactRequestBuilder {
         self
     }
 
+    /// Sets the L0 compaction and returns the updated value.
+    pub fn l0_compaction(mut self, value: bool) -> Self {
+        self.value.l0_compaction = value;
+        self
+    }
+
+    /// Sets the unit used to interpret the target size and returns the updated value.
+    pub fn target_size_unit(mut self, value: TargetSizeUnit) -> Self {
+        self.value.target_size_unit = value;
+        self
+    }
+
     /// Validates the configured values and builds the request.
     pub fn build(self) -> Result<CompactRequest> {
         validate_collection_target(
             self.value.database_name.as_deref(),
             &self.value.collection_name,
         )?;
-        if self.value.target_size < 0 {
-            return Err(Error::validation(
-                "target_size".into(),
-                "must not be negative".into(),
-            ));
-        }
-        Ok(self.value)
+        let CompactRequest {
+            database_name,
+            collection_name,
+            target_size,
+            clustering_compaction,
+            l0_compaction,
+            target_size_unit,
+        } = self.value;
+        let target_size = match target_size {
+            Some(size) => Some(size_to_mb(size, target_size_unit)?),
+            None => None,
+        };
+        Ok(CompactRequest {
+            database_name,
+            collection_name,
+            target_size,
+            clustering_compaction,
+            l0_compaction,
+            target_size_unit: TargetSizeUnit::MB,
+        })
     }
+}
+
+/// Converts a target size expressed in the given unit to megabytes.
+fn size_to_mb(size: i64, unit: TargetSizeUnit) -> Result<i64> {
+    if size <= 0 {
+        return Err(Error::validation(
+            "target_size".into(),
+            "must be a positive integer".into(),
+        ));
+    }
+    let bytes = size
+        .checked_mul(unit.bytes())
+        .ok_or_else(|| Error::validation("target_size".into(), "value is too large".into()))?;
+    let megabytes = bytes / BYTES_PER_MB;
+    if megabytes < 1 {
+        return Err(Error::validation(
+            "target_size".into(),
+            "must be at least 1MB".into(),
+        ));
+    }
+    Ok(megabytes)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1330,39 +1397,107 @@ mod builder_value_tests {
         let value = CompactRequest::empty();
         let expected_database_name: Option<String> = None;
         let expected_collection_name: String = String::new();
-        let expected_target_size: i64 = 0;
+        let expected_target_size: Option<i64> = None;
         let expected_clustering_compaction: bool = false;
+        let expected_l0_compaction: bool = false;
+        let expected_target_size_unit: TargetSizeUnit = TargetSizeUnit::MB;
 
         assert_eq!(value.database_name().to_owned(), expected_database_name);
         assert_eq!(value.collection_name().to_owned(), expected_collection_name);
-        assert_eq!(value.target_size().to_owned(), expected_target_size);
+        assert_eq!(value.target_size(), expected_target_size);
         assert_eq!(
             value.is_clustering_compaction(),
             expected_clustering_compaction
         );
+        assert_eq!(value.is_l0_compaction(), expected_l0_compaction);
+        assert_eq!(value.target_size_unit(), expected_target_size_unit);
     }
 
     #[test]
     fn compact_request_populated_values() {
         let database_name = "database_name-value".to_owned();
         let collection_name = "collection_name-value".to_owned();
-        let target_size = 7;
+        let target_size = 2;
         let clustering_compaction = true;
+        let l0_compaction = true;
         let value = CompactRequest::builder()
             .database_name(database_name.clone())
             .collection_name(collection_name.clone())
-            .target_size(target_size.clone())
-            .clustering_compaction(clustering_compaction.clone())
+            .target_size(target_size)
+            .target_size_unit(TargetSizeUnit::GB)
+            .clustering_compaction(clustering_compaction)
+            .l0_compaction(l0_compaction)
             .build()
             .expect("valid request");
 
         assert_eq!(value.database_name().to_owned(), Some(database_name));
         assert_eq!(value.collection_name().to_owned(), collection_name);
-        assert_eq!(value.target_size().to_owned(), target_size);
-        assert_eq!(
-            value.is_clustering_compaction().to_owned(),
-            clustering_compaction
-        );
+        assert_eq!(value.target_size(), Some(2 * 1024));
+        assert_eq!(value.is_clustering_compaction(), clustering_compaction);
+        assert_eq!(value.is_l0_compaction(), l0_compaction);
+        assert_eq!(value.target_size_unit(), TargetSizeUnit::MB);
+    }
+
+    #[test]
+    fn compact_request_rebuild_via_into_builder_is_idempotent() {
+        let built = CompactRequest::builder()
+            .collection_name("books")
+            .target_size(2)
+            .target_size_unit(TargetSizeUnit::GB)
+            .build()
+            .expect("valid request");
+        assert_eq!(built.target_size(), Some(2 * 1024));
+        assert_eq!(built.target_size_unit(), TargetSizeUnit::MB);
+
+        let rebuilt = built
+            .into_builder()
+            .build()
+            .expect("rebuilt request stays valid");
+        assert_eq!(rebuilt.target_size(), Some(2 * 1024));
+        assert_eq!(rebuilt.target_size_unit(), TargetSizeUnit::MB);
+    }
+
+    #[test]
+    fn compact_request_rejects_non_positive_target_size() {
+        assert!(CompactRequest::builder()
+            .collection_name("books")
+            .target_size(0)
+            .build()
+            .is_err());
+        assert!(CompactRequest::builder()
+            .collection_name("books")
+            .target_size(-1)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn compact_request_maps_l0_and_size_unit_to_proto() {
+        let value = CompactRequest::builder()
+            .collection_name("books")
+            .target_size(1)
+            .target_size_unit(TargetSizeUnit::GB)
+            .clustering_compaction(true)
+            .l0_compaction(true)
+            .build()
+            .expect("valid request")
+            .into_proto("default");
+
+        assert_eq!(value.target_size, 1024);
+        assert!(value.major_compaction);
+        assert!(value.l0_compaction);
+    }
+
+    #[test]
+    fn compact_request_omitted_target_size_uses_server_default() {
+        let value = CompactRequest::builder()
+            .collection_name("books")
+            .build()
+            .expect("valid request")
+            .into_proto("default");
+
+        assert_eq!(value.target_size, 0);
+        assert!(!value.l0_compaction);
     }
 
     #[test]

--- a/src/v2/response/index.rs
+++ b/src/v2/response/index.rs
@@ -145,10 +145,14 @@ impl ListIndexesResponse {
         &self.indexes
     }
 
-    pub(crate) fn from_proto(v: milvus::GetIndexStatisticsResponse) -> Result<Self> {
+    pub(crate) fn from_proto(
+        v: milvus::GetIndexStatisticsResponse,
+        field_name: &str,
+    ) -> Result<Self> {
         let indexes: Vec<IndexDesc> = v
             .index_descriptions
             .into_iter()
+            .filter(|index| field_name.is_empty() || index.field_name == field_name)
             .map(IndexDesc::from_proto)
             .collect::<Result<_>>()?;
         let index_names = indexes.iter().map(|v| v.index_name.clone()).collect();
@@ -268,13 +272,50 @@ mod index_desc_tests {
 
     #[test]
     fn list_indexes_rejects_malformed_params_json() {
-        assert!(
-            super::ListIndexesResponse::from_proto(milvus::GetIndexStatisticsResponse {
+        assert!(super::ListIndexesResponse::from_proto(
+            milvus::GetIndexStatisticsResponse {
                 index_descriptions: vec![malformed_index_description()],
                 ..Default::default()
-            })
-            .is_err()
-        );
+            },
+            "",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn list_indexes_filters_indexes_by_field_name() {
+        let descriptions = vec![
+            milvus::IndexDescription {
+                field_name: "embedding".into(),
+                index_name: "embedding_idx".into(),
+                ..Default::default()
+            },
+            milvus::IndexDescription {
+                field_name: "title".into(),
+                index_name: "title_idx".into(),
+                ..Default::default()
+            },
+        ];
+        let all = super::ListIndexesResponse::from_proto(
+            milvus::GetIndexStatisticsResponse {
+                index_descriptions: descriptions.clone(),
+                ..Default::default()
+            },
+            "",
+        )
+        .expect("valid response");
+        assert_eq!(all.index_names().to_owned(), ["embedding_idx", "title_idx"]);
+
+        let filtered = super::ListIndexesResponse::from_proto(
+            milvus::GetIndexStatisticsResponse {
+                index_descriptions: descriptions,
+                ..Default::default()
+            },
+            "title",
+        )
+        .expect("valid response");
+        assert_eq!(filtered.index_names().to_owned(), ["title_idx"]);
+        assert_eq!(filtered.indexes().len(), 1);
     }
 }
 

--- a/src/v2/types/utility.rs
+++ b/src/v2/types/utility.rs
@@ -115,6 +115,42 @@ impl CompactionStateCode {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// TargetSizeUnit
+///////////////////////////////////////////////////////////////////////////////
+/// Unit used to interpret a compaction target segment size.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TargetSizeUnit {
+    /// Represents the Byte case.
+    Bytes,
+    /// Represents the Kilobyte case.
+    KB,
+    #[default]
+    /// Represents the Megabyte case.
+    MB,
+    /// Represents the Gigabyte case.
+    GB,
+    /// Represents the Terabyte case.
+    TB,
+    /// Represents the Petabyte case.
+    PB,
+}
+
+impl TargetSizeUnit {
+    /// Returns the number of bytes that make up one unit.
+    pub(crate) fn bytes(self) -> i64 {
+        match self {
+            Self::Bytes => 1,
+            Self::KB => 1024,
+            Self::MB => 1024 * 1024,
+            Self::GB => 1024 * 1024 * 1024,
+            Self::TB => 1024_i64.pow(4),
+            Self::PB => 1024_i64.pow(5),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // PersistentSegmentInfo
 ///////////////////////////////////////////////////////////////////////////////
 /// Metadata for a persisted data segment.

--- a/tests/v2/ut/common.rs
+++ b/tests/v2/ut/common.rs
@@ -845,6 +845,20 @@ impl MilvusService for MockMilvus {
         }
     );
     status_method_with!(
+        operate_privilege,
+        pb::OperatePrivilegeRequest,
+        |service, request| {
+            let entity = request.entity.unwrap_or_default();
+            let mut state = service.state.lock().unwrap();
+            if request.r#type == pb::OperatePrivilegeType::Grant as i32 {
+                state.grants.push(entity);
+            } else {
+                state.grants.retain(|grant| grant != &entity);
+            }
+            success_status()
+        }
+    );
+    status_method_with!(
         create_privilege_group,
         pb::CreatePrivilegeGroupRequest,
         |service, request| {

--- a/tests/v2/ut/rbac.rs
+++ b/tests/v2/ut/rbac.rs
@@ -368,3 +368,71 @@ async fn rbac_interfaces_reach_rpc_server() {
     }
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn rbac_v1_privileges_route_to_operate_privilege() {
+    let server = MockServer::start().await;
+    let client = &server.client;
+
+    client
+        .create_role(
+            CreateRoleRequest::builder()
+                .role_name("reader")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .unwrap();
+
+    client
+        .grant_privilege(
+            GrantPrivilegeRequest::builder()
+                .role_name("reader")
+                .database_name("default")
+                .object_type("Global")
+                .object_name("*")
+                .privilege("CreateCollection")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .unwrap();
+    server.assert_called("operate_privilege");
+    server.assert_request_contains(
+        "operate_privilege",
+        &[
+            "name: \"reader\"",
+            "name: \"Global\"",
+            "object_name: \"*\"",
+            "name: \"CreateCollection\"",
+        ],
+    );
+    assert_eq!(server.service.call_count("operate_privilege_v2"), 0);
+
+    client
+        .revoke_privilege(
+            RevokePrivilegeRequest::builder()
+                .role_name("reader")
+                .database_name("default")
+                .object_type("Global")
+                .object_name("*")
+                .privilege("CreateCollection")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .unwrap();
+    server.assert_called("operate_privilege");
+
+    client
+        .drop_role(
+            DropRoleRequest::builder()
+                .role_name("reader")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .unwrap();
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Align several V2 request parameters with the PyMilvus `MilvusClient` baseline for the 2.6 line.

### compact
- Reject `target_size <= 0` (previously `0` was accepted as "server default"; **behavior change on the 2.6 branch**: callers that passed `0` must now omit the field to let the server pick the default target size, matching pymilvus).
- Add `l0_compaction` parameter mapped to `ManualCompactionRequest.l0_compaction`.
- Add `target_size_unit` (`TargetSizeUnit`: B/KB/MB/GB/TB/PB) used to convert `target_size` to megabytes before it is sent on the wire.
- `target_size` and `target_size_unit` are normalized at `build()` time; a built request always reports the value in MB, so `into_builder().build()` round-trips idempotently.

### list_indexes
- Add `field_name` filter; returned indexes are filtered by field name when set (empty means all fields).

### search / hybrid_search / search_iterator
- Enforce `round_decimal` in `-1..=6`, matching pymilvus `is_legal_round_decimal`.

## Tests
- Unit tests for the new `compact` validation/unit conversion, `into_builder` idempotency, `list_indexes` field filter, and `round_decimal` upper-bound rejection.
