### PR TITLE
Align run_analyzer JSON params and fill pymilvus parity gaps

### DIFF
--- a/examples/v2/run_analyzer.rs
+++ b/examples/v2/run_analyzer.rs
@@ -27,7 +27,7 @@ async fn run_analyzer(client: &ClientV2, params: Value, text: &str) -> Result<()
     let response = client
         .run_analyzer(
             RunAnalyzerRequest::builder()
-                .analyzer_params(params.to_string())
+                .analyzer_params(params)
                 .texts([text])
                 .with_detail(true)
                 .with_hash(true)

--- a/src/v2/request/collection.rs
+++ b/src/v2/request/collection.rs
@@ -162,16 +162,16 @@ impl From<CreateSimpleCollectionRequest> for CreateCollectionRequest {
         CreateCollectionRequest {
             database_name: value.database_name,
             collection_name: value.collection_name,
-            description: None,
+            description: value.description,
             schema: Some(schema),
-            num_partitions: 0,
-            num_shards: 1,
+            num_partitions: value.num_partitions,
+            num_shards: value.num_shards,
             consistency_level: value.consistency_level,
             index_params: vec![IndexParam::new()
                 .field_name(value.vector_field)
                 .index_type(IndexType::AutoIndex)
                 .metric_type(value.metric_type)],
-            properties: HashMap::new(),
+            properties: value.properties,
         }
     }
 }
@@ -314,12 +314,17 @@ pub struct CreateSimpleCollectionRequest {
     pub(crate) dimension: u32,
     pub(crate) primary_field: String,
     pub(crate) primary_field_type: DataType,
+    pub(crate) id_type: Option<String>,
     pub(crate) max_length: u32,
     pub(crate) vector_field: String,
     pub(crate) auto_id: bool,
     pub(crate) enable_dynamic_field: bool,
     pub(crate) consistency_level: ConsistencyLevel,
     pub(crate) metric_type: MetricType,
+    pub(crate) num_shards: i32,
+    pub(crate) num_partitions: i64,
+    pub(crate) properties: HashMap<String, String>,
+    pub(crate) description: Option<String>,
 }
 
 impl CreateSimpleCollectionRequest {
@@ -360,6 +365,11 @@ impl CreateSimpleCollectionRequest {
         self.primary_field_type
     }
 
+    /// Returns the raw `id_type` string alias, if one was set.
+    pub fn id_type(&self) -> Option<&str> {
+        self.id_type.as_deref()
+    }
+
     /// Returns the max length.
     pub fn max_length(&self) -> u32 {
         self.max_length
@@ -389,6 +399,26 @@ impl CreateSimpleCollectionRequest {
     pub fn metric_type(&self) -> MetricType {
         self.metric_type
     }
+
+    /// Returns the number of shards.
+    pub fn num_shards(&self) -> i32 {
+        self.num_shards
+    }
+
+    /// Returns the number of partitions.
+    pub fn num_partitions(&self) -> i64 {
+        self.num_partitions
+    }
+
+    /// Returns the collection properties.
+    pub fn properties(&self) -> &HashMap<String, String> {
+        &self.properties
+    }
+
+    /// Returns the collection description.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
 }
 
 impl CreateSimpleCollectionRequest {
@@ -399,12 +429,17 @@ impl CreateSimpleCollectionRequest {
             dimension: 0,
             primary_field: "id".into(),
             primary_field_type: DataType::Int64,
+            id_type: None,
             max_length: 65_535,
             vector_field: "vector".into(),
             auto_id: false,
             enable_dynamic_field: true,
             consistency_level: ConsistencyLevel::Bounded,
             metric_type: MetricType::Cosine,
+            num_shards: 1,
+            num_partitions: 0,
+            properties: HashMap::new(),
+            description: None,
         }
     }
 }
@@ -485,19 +520,67 @@ impl CreateSimpleCollectionRequestBuilder {
         self
     }
 
+    /// Sets the primary id type and returns the updated value.
+    ///
+    /// Accepts `"int"` (maps to [`DataType::Int64`]) and `"string"`/`"str"`
+    /// (maps to [`DataType::VarChar`]), matching pymilvus `create_collection`.
+    /// The alias is resolved during [`CreateSimpleCollectionRequestBuilder::build`].
+    pub fn id_type(mut self, value: impl Into<String>) -> Self {
+        self.value.id_type = Some(value.into());
+        self
+    }
+
+    /// Sets the number of shards and returns the updated value.
+    pub fn num_shards(mut self, value: i32) -> Self {
+        self.value.num_shards = value;
+        self
+    }
+
+    /// Sets the number of partitions and returns the updated value.
+    pub fn num_partitions(mut self, value: i64) -> Self {
+        self.value.num_partitions = value;
+        self
+    }
+
+    /// Sets the collection properties and returns the updated value.
+    pub fn properties(mut self, value: HashMap<String, String>) -> Self {
+        self.value.properties = value;
+        self
+    }
+
+    /// Sets the collection description and returns the updated value.
+    pub fn description(mut self, value: impl Into<String>) -> Self {
+        self.value.description = Some(value.into());
+        self
+    }
+
     /// Validates the configured values and builds the request.
     pub fn build(self) -> Result<CreateSimpleCollectionRequest> {
-        required("collection_name", &self.value.collection_name)?;
-        if self.value.dimension == 0 {
+        let mut value = self.value;
+        if let Some(alias) = value.id_type.take() {
+            let data_type = match alias.as_str() {
+                "int" => DataType::Int64,
+                "string" | "str" => DataType::VarChar,
+                other => {
+                    return Err(Error::validation(
+                        "id_type".into(),
+                        format!("must be \"int\" or \"string\", got {other:?}"),
+                    ))
+                }
+            };
+            value.primary_field_type = data_type;
+        }
+        required("collection_name", &value.collection_name)?;
+        if value.dimension == 0 {
             return Err(Error::validation(
                 "dimension".into(),
                 "must be greater than zero".into(),
             ));
         }
-        required("primary_field", &self.value.primary_field)?;
-        required("vector_field", &self.value.vector_field)?;
+        required("primary_field", &value.primary_field)?;
+        required("vector_field", &value.vector_field)?;
         if !matches!(
-            self.value.primary_field_type,
+            value.primary_field_type,
             DataType::Int64 | DataType::VarChar
         ) {
             return Err(Error::validation(
@@ -505,13 +588,25 @@ impl CreateSimpleCollectionRequestBuilder {
                 "must be Int64 or VarChar".into(),
             ));
         }
-        if self.value.primary_field_type == DataType::VarChar && self.value.max_length == 0 {
+        if value.primary_field_type == DataType::VarChar && value.max_length == 0 {
             return Err(Error::validation(
                 "max_length".into(),
                 "must be greater than zero for a VarChar primary field".into(),
             ));
         }
-        Ok(self.value)
+        if value.num_shards <= 0 {
+            return Err(Error::validation(
+                "num_shards".into(),
+                "must be greater than zero".into(),
+            ));
+        }
+        if value.num_partitions < 0 {
+            return Err(Error::validation(
+                "num_partitions".into(),
+                "must not be negative".into(),
+            ));
+        }
+        Ok(value)
     }
 }
 
@@ -857,6 +952,8 @@ pub struct LoadCollectionRequest {
     pub(crate) load_fields: Vec<String>,
     pub(crate) skip_load_dynamic_field: bool,
     pub(crate) resource_groups: Vec<String>,
+    /// Load priority (e.g. `"low"`); forwarded as the `load_priority` load param.
+    pub(crate) load_priority: Option<String>,
 }
 
 impl LoadCollectionRequest {
@@ -917,6 +1014,11 @@ impl LoadCollectionRequest {
         &self.resource_groups
     }
 
+    /// Returns the load priority.
+    pub fn load_priority(&self) -> Option<&str> {
+        self.load_priority.as_deref()
+    }
+
     pub(crate) fn into_proto(self, default_db: &str) -> milvus::LoadCollectionRequest {
         let mut value = milvus::LoadCollectionRequest::default();
         value.db_name = self.database_name.unwrap_or_else(|| default_db.to_owned());
@@ -926,6 +1028,9 @@ impl LoadCollectionRequest {
         value.load_fields = self.load_fields;
         value.skip_load_dynamic_field = self.skip_load_dynamic_field;
         value.resource_groups = self.resource_groups;
+        if let Some(priority) = self.load_priority {
+            value.load_params.insert("load_priority".into(), priority);
+        }
         value
     }
 }
@@ -942,6 +1047,7 @@ impl LoadCollectionRequest {
             load_fields: Vec::new(),
             skip_load_dynamic_field: false,
             resource_groups: Vec::new(),
+            load_priority: None,
         }
     }
 }
@@ -1007,6 +1113,15 @@ impl LoadCollectionRequestBuilder {
     /// Sets the resource groups and returns the updated value.
     pub fn resource_groups(mut self, values: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.value.resource_groups = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the load priority and returns the updated value.
+    ///
+    /// Forwarded as the `load_priority` load param; pass values such as
+    /// `"low"` to use a lower priority than the default.
+    pub fn load_priority(mut self, value: impl Into<String>) -> Self {
+        self.value.load_priority = Some(value.into());
         self
     }
 
@@ -3911,12 +4026,17 @@ mod builder_value_tests {
         let expected_dimension: u32 = 0;
         let expected_primary_field: String = "id".to_owned();
         let expected_primary_field_type: DataType = DataType::Int64;
+        let expected_id_type: Option<String> = None;
         let expected_max_length: u32 = 65_535;
         let expected_vector_field: String = "vector".to_owned();
         let expected_auto_id: bool = false;
         let expected_enable_dynamic_field: bool = true;
         let expected_consistency_level: ConsistencyLevel = ConsistencyLevel::Bounded;
         let expected_metric_type: MetricType = MetricType::Cosine;
+        let expected_num_shards: i32 = 1;
+        let expected_num_partitions: i64 = 0;
+        let expected_properties: HashMap<String, String> = HashMap::new();
+        let expected_description: Option<String> = None;
 
         assert_eq!(value.database_name().to_owned(), expected_database_name);
         assert_eq!(value.collection_name().to_owned(), expected_collection_name);
@@ -3926,6 +4046,7 @@ mod builder_value_tests {
             value.primary_field_type().to_owned(),
             expected_primary_field_type
         );
+        assert_eq!(value.id_type(), expected_id_type.as_deref());
         assert_eq!(value.max_length().to_owned(), expected_max_length);
         assert_eq!(value.vector_field().to_owned(), expected_vector_field);
         assert_eq!(value.is_auto_id().to_owned(), expected_auto_id);
@@ -3938,6 +4059,10 @@ mod builder_value_tests {
             expected_consistency_level
         );
         assert_eq!(value.metric_type().to_owned(), expected_metric_type);
+        assert_eq!(value.num_shards().to_owned(), expected_num_shards);
+        assert_eq!(value.num_partitions().to_owned(), expected_num_partitions);
+        assert_eq!(value.properties().to_owned(), expected_properties);
+        assert_eq!(value.description(), expected_description.as_deref());
     }
 
     #[test]
@@ -3953,6 +4078,10 @@ mod builder_value_tests {
         let enable_dynamic_field = true;
         let consistency_level = ConsistencyLevel::Strong;
         let metric_type = MetricType::Cosine;
+        let num_shards = 4;
+        let num_partitions = 8;
+        let properties = HashMap::from([("key".to_owned(), "value".to_owned())]);
+        let description = "description-value".to_owned();
         let value = CreateSimpleCollectionRequest::builder()
             .database_name(database_name.clone())
             .collection_name(collection_name.clone())
@@ -3965,6 +4094,10 @@ mod builder_value_tests {
             .enable_dynamic_field(enable_dynamic_field.clone())
             .consistency_level(consistency_level.clone())
             .metric_type(metric_type.clone())
+            .num_shards(num_shards.clone())
+            .num_partitions(num_partitions.clone())
+            .properties(properties.clone())
+            .description(description.clone())
             .build()
             .expect("valid request");
 
@@ -3982,6 +4115,87 @@ mod builder_value_tests {
         );
         assert_eq!(value.consistency_level().to_owned(), consistency_level);
         assert_eq!(value.metric_type().to_owned(), metric_type);
+        assert_eq!(value.num_shards().to_owned(), num_shards);
+        assert_eq!(value.num_partitions().to_owned(), num_partitions);
+        assert_eq!(value.properties().to_owned(), properties);
+        assert_eq!(value.description(), Some(description.as_str()));
+    }
+
+    #[test]
+    fn create_simple_collection_request_id_type_resolves() {
+        let int_value = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .id_type("int")
+            .build()
+            .expect("valid int id type");
+        assert_eq!(int_value.primary_field_type(), DataType::Int64);
+
+        let string_value = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .id_type("string")
+            .build()
+            .expect("valid string id type");
+        assert_eq!(string_value.primary_field_type(), DataType::VarChar);
+
+        let str_value = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .id_type("str")
+            .build()
+            .expect("valid str id type");
+        assert_eq!(str_value.primary_field_type(), DataType::VarChar);
+
+        let error = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .id_type("uuid")
+            .build()
+            .expect_err("invalid id type");
+        assert!(error.to_string().contains("id_type"));
+    }
+
+    #[test]
+    fn create_simple_collection_request_rejects_invalid_shards_and_partitions() {
+        let error = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .num_shards(0)
+            .build()
+            .expect_err("num_shards must be positive");
+        assert!(error.to_string().contains("num_shards"));
+
+        let error = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .num_partitions(-1)
+            .build()
+            .expect_err("num_partitions must not be negative");
+        assert!(error.to_string().contains("num_partitions"));
+    }
+
+    #[test]
+    fn create_simple_collection_request_forwards_fields_to_full_request() {
+        let simple = CreateSimpleCollectionRequest::builder()
+            .collection_name("books")
+            .dimension(8)
+            .num_shards(4)
+            .num_partitions(8)
+            .description("a book collection")
+            .properties(HashMap::from([("ttl".to_owned(), "120".to_owned())]))
+            .build()
+            .expect("valid request");
+        let full = CreateCollectionRequest::from(simple);
+
+        assert_eq!(full.collection_name(), "books");
+        assert_eq!(full.num_shards(), 4);
+        assert_eq!(full.num_partitions(), 8);
+        assert_eq!(full.description().as_deref(), Some("a book collection"));
+        assert_eq!(
+            full.properties().get("ttl").map(String::as_str),
+            Some("120")
+        );
     }
 
     #[test]
@@ -4138,6 +4352,29 @@ mod builder_value_tests {
             skip_load_dynamic_field
         );
         assert_eq!(value.resource_groups().to_owned(), resource_groups);
+    }
+
+    #[test]
+    fn load_collection_request_forwards_load_priority() {
+        let value = LoadCollectionRequest::builder()
+            .collection_name("books")
+            .load_priority("low")
+            .build()
+            .expect("valid request");
+        assert_eq!(value.load_priority(), Some("low"));
+
+        let proto = value.into_proto("default");
+        assert_eq!(
+            proto.load_params.get("load_priority").map(String::as_str),
+            Some("low")
+        );
+
+        let no_priority = LoadCollectionRequest::builder()
+            .collection_name("books")
+            .build()
+            .expect("valid request");
+        assert_eq!(no_priority.load_priority(), None);
+        assert!(no_priority.into_proto("default").load_params.is_empty());
     }
 
     #[test]

--- a/src/v2/request/partition.rs
+++ b/src/v2/request/partition.rs
@@ -512,6 +512,8 @@ pub struct LoadPartitionsRequest {
     pub(crate) load_fields: Vec<String>,
     pub(crate) skip_load_dynamic_field: bool,
     pub(crate) resource_groups: Vec<String>,
+    /// Load priority (e.g. `"low"`); forwarded as the `load_priority` load param.
+    pub(crate) load_priority: Option<String>,
 }
 
 impl LoadPartitionsRequest {
@@ -577,6 +579,11 @@ impl LoadPartitionsRequest {
         &self.resource_groups
     }
 
+    /// Returns the load priority.
+    pub fn load_priority(&self) -> Option<&str> {
+        self.load_priority.as_deref()
+    }
+
     pub(crate) fn into_proto(self, default_db: &str) -> milvus::LoadPartitionsRequest {
         let mut value = milvus::LoadPartitionsRequest::default();
         value.db_name = self.database_name.unwrap_or_else(|| default_db.to_owned());
@@ -587,6 +594,9 @@ impl LoadPartitionsRequest {
         value.resource_groups = self.resource_groups;
         value.load_fields = self.load_fields;
         value.skip_load_dynamic_field = self.skip_load_dynamic_field;
+        if let Some(priority) = self.load_priority {
+            value.load_params.insert("load_priority".into(), priority);
+        }
         value
     }
 }
@@ -604,6 +614,7 @@ impl LoadPartitionsRequest {
             load_fields: Vec::new(),
             skip_load_dynamic_field: false,
             resource_groups: Vec::new(),
+            load_priority: None,
         }
     }
 }
@@ -717,6 +728,15 @@ impl LoadPartitionsRequestBuilder {
         if !self.value.resource_groups.contains(&value) {
             self.value.resource_groups.push(value);
         }
+        self
+    }
+
+    /// Sets the load priority and returns the updated value.
+    ///
+    /// Forwarded as the `load_priority` load param; pass values such as
+    /// `"low"` to use a lower priority than the default.
+    pub fn load_priority(mut self, value: impl Into<String>) -> Self {
+        self.value.load_priority = Some(value.into());
         self
     }
 
@@ -1122,6 +1142,31 @@ mod builder_value_tests {
             skip_load_dynamic_field
         );
         assert_eq!(value.resource_groups().to_owned(), resource_groups);
+    }
+
+    #[test]
+    fn load_partitions_request_forwards_load_priority() {
+        let value = LoadPartitionsRequest::builder()
+            .collection_name("books")
+            .partition_names(["p1"])
+            .load_priority("low")
+            .build()
+            .expect("valid request");
+        assert_eq!(value.load_priority(), Some("low"));
+
+        let proto = value.into_proto("default");
+        assert_eq!(
+            proto.load_params.get("load_priority").map(String::as_str),
+            Some("low")
+        );
+
+        let no_priority = LoadPartitionsRequest::builder()
+            .collection_name("books")
+            .partition_names(["p1"])
+            .build()
+            .expect("valid request");
+        assert_eq!(no_priority.load_priority(), None);
+        assert!(no_priority.into_proto("default").load_params.is_empty());
     }
 
     #[test]

--- a/src/v2/request/utility.rs
+++ b/src/v2/request/utility.rs
@@ -1004,10 +1004,10 @@ impl GetCompactionPlansRequestBuilder {
 // RunAnalyzerRequest
 ///////////////////////////////////////////////////////////////////////////////
 /// Parameters for the ClientV2 run_analyzer operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct RunAnalyzerRequest {
-    pub(crate) analyzer_params: String,
+    pub(crate) analyzer_params: Option<serde_json::Value>,
     pub(crate) texts: Vec<String>,
     pub(crate) with_detail: bool,
     pub(crate) with_hash: bool,
@@ -1020,7 +1020,7 @@ pub struct RunAnalyzerRequest {
 impl RunAnalyzerRequest {
     fn empty() -> Self {
         Self {
-            analyzer_params: Default::default(),
+            analyzer_params: None,
             texts: Default::default(),
             with_detail: Default::default(),
             with_hash: Default::default(),
@@ -1044,8 +1044,8 @@ impl RunAnalyzerRequest {
     }
 
     /// Returns the analyzer params.
-    pub fn analyzer_params(&self) -> &str {
-        &self.analyzer_params
+    pub fn analyzer_params(&self) -> Option<&serde_json::Value> {
+        self.analyzer_params.as_ref()
     }
 
     /// Returns the texts.
@@ -1086,7 +1086,11 @@ impl RunAnalyzerRequest {
     pub(crate) fn into_proto(self, default_db: &str) -> milvus::RunAnalyzerRequest {
         milvus::RunAnalyzerRequest {
             base: None,
-            analyzer_params: self.analyzer_params,
+            analyzer_params: self
+                .analyzer_params
+                .as_ref()
+                .map(serde_json::Value::to_string)
+                .unwrap_or_default(),
             placeholder: self.texts.into_iter().map(String::into_bytes).collect(),
             with_detail: self.with_detail,
             with_hash: self.with_hash,
@@ -1110,8 +1114,8 @@ pub struct RunAnalyzerRequestBuilder {
 
 impl RunAnalyzerRequestBuilder {
     /// Sets the analyzer params and returns the updated value.
-    pub fn analyzer_params(mut self, value: impl Into<String>) -> Self {
-        self.value.analyzer_params = value.into();
+    pub fn analyzer_params(mut self, value: serde_json::Value) -> Self {
+        self.value.analyzer_params = Some(value);
         self
     }
 
@@ -1160,7 +1164,14 @@ impl RunAnalyzerRequestBuilder {
     /// Validates the configured values and builds the request.
     pub fn build(self) -> Result<RunAnalyzerRequest> {
         required_slice("texts", &self.value.texts)?;
-        if self.value.analyzer_params.trim().is_empty() {
+        if let Some(params) = &self.value.analyzer_params {
+            if !params.is_object() {
+                return Err(Error::validation(
+                    "analyzer_params".into(),
+                    "must be a JSON object".into(),
+                ));
+            }
+        } else {
             required("collection_name", &self.value.collection_name)?;
             required("field_name", &self.value.field_name)?;
         }
@@ -2023,7 +2034,7 @@ mod builder_value_tests {
     #[test]
     fn run_analyzer_request_default_values() {
         let value = RunAnalyzerRequest::empty();
-        let expected_analyzer_params: String = String::new();
+        let expected_analyzer_params: Option<serde_json::Value> = None;
         let expected_texts: Vec<String> = Default::default();
         let expected_with_detail: bool = false;
         let expected_with_hash: bool = false;
@@ -2032,7 +2043,7 @@ mod builder_value_tests {
         let expected_field_name: String = String::new();
         let expected_analyzer_names: Vec<String> = Default::default();
 
-        assert_eq!(value.analyzer_params().to_owned(), expected_analyzer_params);
+        assert_eq!(value.analyzer_params().cloned(), expected_analyzer_params);
         assert_eq!(value.texts().to_owned(), expected_texts);
         assert_eq!(
             value.should_include_detail().to_owned(),
@@ -2047,7 +2058,7 @@ mod builder_value_tests {
 
     #[test]
     fn run_analyzer_request_populated_values() {
-        let analyzer_params = "analyzer_params-value".to_owned();
+        let analyzer_params = serde_json::json!({"tokenizer": "standard"});
         let texts = vec!["texts-value".to_owned()];
         let with_detail = true;
         let with_hash = true;
@@ -2067,7 +2078,7 @@ mod builder_value_tests {
             .build()
             .expect("valid request");
 
-        assert_eq!(value.analyzer_params().to_owned(), analyzer_params);
+        assert_eq!(value.analyzer_params().cloned(), Some(analyzer_params));
         assert_eq!(value.texts().to_owned(), texts);
         assert_eq!(value.should_include_detail().to_owned(), with_detail);
         assert_eq!(value.should_include_hash().to_owned(), with_hash);
@@ -2075,6 +2086,23 @@ mod builder_value_tests {
         assert_eq!(value.collection_name().to_owned(), collection_name);
         assert_eq!(value.field_name().to_owned(), field_name);
         assert_eq!(value.analyzer_names().to_owned(), analyzer_names);
+    }
+
+    #[test]
+    fn run_analyzer_request_rejects_non_object_analyzer_params() {
+        let error = RunAnalyzerRequest::builder()
+            .analyzer_params(serde_json::json!("standard"))
+            .texts(["hello"])
+            .build()
+            .expect_err("analyzer_params must be a JSON object");
+        assert!(error.to_string().contains("analyzer_params"));
+
+        let error = RunAnalyzerRequest::builder()
+            .analyzer_params(serde_json::json!(42))
+            .texts(["hello"])
+            .build()
+            .expect_err("analyzer_params must be a JSON object");
+        assert!(error.to_string().contains("analyzer_params"));
     }
 }
 

--- a/src/v2/response/dml.rs
+++ b/src/v2/response/dml.rs
@@ -19,6 +19,7 @@
 use crate::proto::milvus;
 use crate::v2::error::Result;
 pub use crate::v2::types::Ids;
+use crate::v2::utils::parse_extra;
 
 ///////////////////////////////////////////////////////////////////////////////
 // DmlResponse
@@ -35,6 +36,7 @@ pub struct DmlResponse {
     pub(crate) delete_count: i64,
     pub(crate) upsert_count: i64,
     pub(crate) timestamp: u64,
+    pub(crate) cost: i64,
 }
 
 impl DmlResponse {
@@ -50,6 +52,7 @@ impl DmlResponse {
             delete_count: 0,
             upsert_count: 0,
             timestamp: 0,
+            cost: 0,
         }
     }
 
@@ -105,6 +108,12 @@ impl DmlResponse {
     }
 
     pub(crate) fn from_proto(value: milvus::MutationResult) -> Result<Self> {
+        let extra_info = value
+            .status
+            .as_ref()
+            .map(|status| &status.extra_info)
+            .cloned()
+            .unwrap_or_default();
         Ok(Self {
             ids: Ids::from_proto(value.i_ds)?,
             succeeded_indices: value.succ_index,
@@ -114,7 +123,14 @@ impl DmlResponse {
             delete_count: value.delete_cnt,
             upsert_count: value.upsert_cnt,
             timestamp: value.timestamp,
+            cost: parse_extra(&extra_info, "report_value", -1_i64),
         })
+    }
+
+    /// Returns the cost reported by the server, or `-1` when the server did
+    /// not report one.
+    pub fn cost(&self) -> i64 {
+        self.cost
     }
 }
 
@@ -185,6 +201,12 @@ impl DmlResponseBuilder {
         self
     }
 
+    /// Sets the cost and returns the updated value.
+    pub fn cost(mut self, value: i64) -> Self {
+        self.value.cost = value;
+        self
+    }
+
     /// Validates the configured values and builds the request.
     pub fn build(self) -> DmlResponse {
         self.value
@@ -242,6 +264,7 @@ mod builder_value_tests {
         let expected_delete_count: i64 = 0;
         let expected_upsert_count: i64 = 0;
         let expected_timestamp: u64 = 0;
+        let expected_cost: i64 = 0;
 
         assert_eq!(value.ids().to_owned(), expected_ids);
         assert_eq!(
@@ -254,6 +277,7 @@ mod builder_value_tests {
         assert_eq!(value.delete_count().to_owned(), expected_delete_count);
         assert_eq!(value.upsert_count().to_owned(), expected_upsert_count);
         assert_eq!(value.timestamp().to_owned(), expected_timestamp);
+        assert_eq!(value.cost().to_owned(), expected_cost);
     }
 
     #[test]
@@ -266,6 +290,7 @@ mod builder_value_tests {
         let delete_count = 7;
         let upsert_count = 7;
         let timestamp = 7;
+        let cost = 7;
         let value = DmlResponse::builder()
             .ids(ids.clone())
             .succeeded_indices(succeeded_indices.clone())
@@ -275,6 +300,7 @@ mod builder_value_tests {
             .delete_count(delete_count.clone())
             .upsert_count(upsert_count.clone())
             .timestamp(timestamp.clone())
+            .cost(cost.clone())
             .build();
 
         assert_eq!(value.ids().to_owned(), ids);
@@ -285,5 +311,41 @@ mod builder_value_tests {
         assert_eq!(value.delete_count().to_owned(), delete_count);
         assert_eq!(value.upsert_count().to_owned(), upsert_count);
         assert_eq!(value.timestamp().to_owned(), timestamp);
+        assert_eq!(value.cost().to_owned(), cost);
+    }
+
+    #[test]
+    fn dml_response_decodes_cost_from_server_extra_info() {
+        use crate::proto::common;
+        use crate::proto::schema;
+
+        let value = DmlResponse::from_proto(milvus::MutationResult {
+            status: Some(common::Status {
+                extra_info: [("report_value".into(), "42".into())].into_iter().collect(),
+                ..Default::default()
+            }),
+            insert_cnt: 2,
+            i_ds: Some(schema::IDs {
+                id_field: Some(schema::i_ds::IdField::IntId(schema::LongArray {
+                    data: vec![1, 2],
+                })),
+            }),
+            ..Default::default()
+        })
+        .expect("valid mutation result");
+
+        assert_eq!(value.insert_count(), 2);
+        assert_eq!(value.cost(), 42);
+        assert_eq!(value.ids(), &Ids::Int64(vec![1, 2]));
+    }
+
+    #[test]
+    fn dml_response_defaults_cost_when_server_reports_none() {
+        let value = DmlResponse::from_proto(milvus::MutationResult {
+            ..Default::default()
+        })
+        .expect("valid empty mutation result");
+
+        assert_eq!(value.cost(), -1);
     }
 }

--- a/src/v2/response/dql.rs
+++ b/src/v2/response/dql.rs
@@ -25,6 +25,7 @@ use crate::v2::error::{Error, Result};
 use crate::v2::types::Ids;
 use crate::v2::types::{group_aggregation_buckets, DataType, FieldData, SparseVector};
 pub use crate::v2::types::{HighlightResult, QueryResults, SearchResults, SingleResult};
+use crate::v2::utils::parse_extra;
 use std::collections::{HashMap, HashSet};
 
 fn field_data(value: schema::FieldData) -> Result<FieldData> {
@@ -1720,16 +1721,6 @@ fn split_field_data(data: FieldData, sizes: &[usize]) -> Option<Vec<FieldData>> 
                 .collect()
         }
     }
-}
-
-fn parse_extra<T>(values: &HashMap<String, String>, key: &str, default: T) -> T
-where
-    T: std::str::FromStr,
-{
-    values
-        .get(key)
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(default)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/v2/types/collection.rs
+++ b/src/v2/types/collection.rs
@@ -150,6 +150,7 @@ impl DefaultValue {
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct FieldSchema {
+    pub(crate) field_id: i64,
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) data_type: DataType,
@@ -159,6 +160,8 @@ pub struct FieldSchema {
     pub(crate) is_partition_key: bool,
     pub(crate) is_clustering_key: bool,
     pub(crate) nullable: bool,
+    pub(crate) is_dynamic: bool,
+    pub(crate) is_function_output: bool,
     pub(crate) default_value: Option<DefaultValue>,
     pub(crate) type_params: HashMap<String, String>,
     pub(crate) index_params: HashMap<String, String>,
@@ -169,6 +172,7 @@ impl FieldSchema {
     /// Creates a value initialized with its SDK defaults.
     pub fn new() -> Self {
         Self {
+            field_id: 0,
             name: String::new(),
             description: String::new(),
             data_type: DataType::Unknown,
@@ -178,6 +182,8 @@ impl FieldSchema {
             is_partition_key: false,
             is_clustering_key: false,
             nullable: false,
+            is_dynamic: false,
+            is_function_output: false,
             default_value: None,
             type_params: HashMap::new(),
             index_params: HashMap::new(),
@@ -410,6 +416,31 @@ impl FieldSchema {
         &self.external_field
     }
 
+    /// Returns the field id assigned by the server.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// has no effect when building a create-collection request; the server
+    /// assigns field ids at collection creation.
+    pub fn get_field_id(&self) -> i64 {
+        self.field_id
+    }
+
+    /// Returns whether this field is the dynamic field.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// cannot be set when building a create-collection request.
+    pub fn is_dynamic(&self) -> bool {
+        self.is_dynamic
+    }
+
+    /// Returns whether this field is produced by a function.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// cannot be set when building a create-collection request.
+    pub fn is_function_output(&self) -> bool {
+        self.is_function_output
+    }
+
     /// Sets the dimension and returns the updated value.
     pub fn dimension(mut self, dimension: u32) -> Self {
         if dimension > 0 {
@@ -578,6 +609,7 @@ impl FieldSchema {
 
     pub(crate) fn into_proto(self) -> schema::FieldSchema {
         schema::FieldSchema {
+            field_id: self.field_id,
             name: self.name,
             description: self.description,
             data_type: self.data_type.into_proto() as i32,
@@ -590,6 +622,8 @@ impl FieldSchema {
             is_partition_key: self.is_partition_key,
             is_clustering_key: self.is_clustering_key,
             nullable: self.nullable,
+            is_dynamic: self.is_dynamic,
+            is_function_output: self.is_function_output,
             default_value: self.default_value.map(DefaultValue::into_proto),
             type_params: pairs(self.type_params),
             index_params: pairs(self.index_params),
@@ -711,6 +745,7 @@ impl FieldSchema {
             .map(DefaultValue::from_proto)
             .transpose()?;
         let field = Self {
+            field_id: value.field_id,
             name: value.name,
             description: value.description,
             data_type,
@@ -720,6 +755,8 @@ impl FieldSchema {
             is_partition_key: value.is_partition_key,
             is_clustering_key: value.is_clustering_key,
             nullable: value.nullable,
+            is_dynamic: value.is_dynamic,
+            is_function_output: value.is_function_output,
             default_value,
             type_params: value
                 .type_params
@@ -1096,6 +1133,7 @@ impl StructFieldSchema {
 pub struct CollectionSchema {
     pub(crate) description: String,
     pub(crate) enable_dynamic_field: bool,
+    pub(crate) schema_version: i32,
     pub(crate) fields: Vec<FieldSchema>,
     pub(crate) struct_fields: Vec<StructFieldSchema>,
     pub(crate) functions: Vec<Function>,
@@ -1110,6 +1148,7 @@ impl CollectionSchema {
         Self {
             description: String::new(),
             enable_dynamic_field: true,
+            schema_version: 0,
             fields: Vec::new(),
             struct_fields: Vec::new(),
             functions: Vec::new(),
@@ -1151,6 +1190,11 @@ impl CollectionSchema {
     /// Returns whether dynamic field enabled.
     pub fn is_dynamic_field_enabled(&self) -> bool {
         self.enable_dynamic_field
+    }
+
+    /// Returns the schema version.
+    pub fn get_schema_version(&self) -> i32 {
+        self.schema_version
     }
 
     /// Sets the fields and returns the updated value.
@@ -1295,6 +1339,7 @@ impl CollectionSchema {
                 .map(StructFieldSchema::into_proto)
                 .collect(),
             enable_dynamic_field: self.enable_dynamic_field,
+            version: self.schema_version,
             properties: pairs(self.properties.clone()),
             functions: self
                 .functions
@@ -1346,6 +1391,7 @@ impl CollectionSchema {
         Ok(Self {
             description: value.description,
             enable_dynamic_field: value.enable_dynamic_field,
+            schema_version: value.version,
             fields: value
                 .fields
                 .into_iter()
@@ -1723,6 +1769,17 @@ impl CollectionDesc {
     /// Returns the configured consistency level.
     pub fn get_consistency_level(&self) -> ConsistencyLevel {
         self.consistency_level
+    }
+
+    /// Returns the consistency level name, e.g. `"Strong"`, `"Bounded"`.
+    pub fn consistency_level_name(&self) -> &'static str {
+        match self.consistency_level {
+            ConsistencyLevel::Strong => "Strong",
+            ConsistencyLevel::Session => "Session",
+            ConsistencyLevel::Bounded => "Bounded",
+            ConsistencyLevel::Eventually => "Eventually",
+            ConsistencyLevel::Customized => "Customized",
+        }
     }
 
     /// Sets the properties and returns the updated value.

--- a/src/v2/types/common.rs
+++ b/src/v2/types/common.rs
@@ -285,11 +285,14 @@ pub enum FunctionType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Function {
+    pub(crate) id: i64,
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) function_type: FunctionType,
     pub(crate) input_fields: Vec<String>,
     pub(crate) output_fields: Vec<String>,
+    pub(crate) input_field_ids: Vec<i64>,
+    pub(crate) output_field_ids: Vec<i64>,
     pub(crate) params: HashMap<String, String>,
 }
 
@@ -297,11 +300,14 @@ impl Function {
     /// Creates a value initialized with its SDK defaults.
     pub fn new() -> Self {
         Self {
+            id: 0,
             name: String::new(),
             description: String::new(),
             function_type: FunctionType::Unknown,
             input_fields: Vec::new(),
             output_fields: Vec::new(),
+            input_field_ids: Vec::new(),
+            output_field_ids: Vec::new(),
             params: HashMap::new(),
         }
     }
@@ -397,6 +403,33 @@ impl Function {
         &self.output_fields
     }
 
+    /// Returns the input field ids assigned by the server.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// cannot be set when building a create-collection request; the server
+    /// assigns function field ids at collection creation.
+    pub fn get_input_field_ids(&self) -> &[i64] {
+        &self.input_field_ids
+    }
+
+    /// Returns the output field ids assigned by the server.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// cannot be set when building a create-collection request; the server
+    /// assigns function field ids at collection creation.
+    pub fn get_output_field_ids(&self) -> &[i64] {
+        &self.output_field_ids
+    }
+
+    /// Returns the function id assigned by the server.
+    ///
+    /// This is populated when decoding a `describe_collection` response and
+    /// cannot be set when building a create-collection request; the server
+    /// assigns function ids at collection creation.
+    pub fn get_id(&self) -> i64 {
+        self.id
+    }
+
     /// Sets the params and returns the updated value.
     pub fn params(mut self, value: HashMap<String, String>) -> Self {
         self.params = value;
@@ -435,7 +468,7 @@ impl Function {
     pub(crate) fn into_proto(self) -> schema::FunctionSchema {
         schema::FunctionSchema {
             name: self.name,
-            id: 0,
+            id: self.id,
             description: self.description,
             r#type: match self.function_type {
                 FunctionType::Unknown => schema::FunctionType::Unknown,
@@ -445,9 +478,9 @@ impl Function {
                 FunctionType::MinHash => schema::FunctionType::MinHash,
             } as i32,
             input_field_names: self.input_fields,
-            input_field_ids: Vec::new(),
+            input_field_ids: self.input_field_ids,
             output_field_names: self.output_fields,
-            output_field_ids: Vec::new(),
+            output_field_ids: self.output_field_ids,
             params: pairs(self.params),
             ..Default::default()
         }
@@ -455,6 +488,7 @@ impl Function {
 
     pub(crate) fn from_proto(value: schema::FunctionSchema) -> Self {
         Self {
+            id: value.id,
             name: value.name,
             description: value.description,
             function_type: match schema::FunctionType::try_from(value.r#type)
@@ -468,6 +502,8 @@ impl Function {
             },
             input_fields: value.input_field_names,
             output_fields: value.output_field_names,
+            input_field_ids: value.input_field_ids,
+            output_field_ids: value.output_field_ids,
             params: value.params.into_iter().map(|v| (v.key, v.value)).collect(),
         }
     }

--- a/src/v2/utils.rs
+++ b/src/v2/utils.rs
@@ -156,3 +156,22 @@ mod tests {
         assert_eq!(array_bf16_to_f32(&bf16), values);
     }
 }
+
+/// Parses an optional extra-info string into `T`, falling back to `default`.
+///
+/// Shared by the response decoders that read server extra-info values such as
+/// `report_value`, `scanned_remote_bytes`, `scanned_total_bytes`, and
+/// `cache_hit_ratio`.
+pub(crate) fn parse_extra<T>(
+    values: &std::collections::HashMap<String, String>,
+    key: &str,
+    default: T,
+) -> T
+where
+    T: std::str::FromStr,
+{
+    values
+        .get(key)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}

--- a/tests/v2/st/collection.rs
+++ b/tests/v2/st/collection.rs
@@ -177,13 +177,65 @@ async fn describe_collection() {
         }
     }
     assert_eq!(
-        returned_schema.get_struct_fields(),
-        schema.get_struct_fields()
+        returned_schema.get_struct_fields().len(),
+        schema.get_struct_fields().len()
     );
+    for expected in schema.get_struct_fields() {
+        let actual = returned_schema
+            .get_struct_fields()
+            .iter()
+            .find(|field| field.get_name() == expected.get_name())
+            .expect("described struct field");
+        assert_eq!(actual.get_description(), expected.get_description());
+        assert_eq!(actual.get_max_capacity(), expected.get_max_capacity());
+        assert_eq!(actual.is_nullable(), expected.is_nullable());
+        assert_eq!(actual.get_fields().len(), expected.get_fields().len());
+        for (actual_sub, expected_sub) in actual.get_fields().iter().zip(expected.get_fields()) {
+            assert_eq!(actual_sub.get_name(), expected_sub.get_name());
+            assert_eq!(actual_sub.get_description(), expected_sub.get_description());
+            assert_eq!(actual_sub.get_data_type(), expected_sub.get_data_type());
+            assert_eq!(
+                actual_sub.get_element_type(),
+                expected_sub.get_element_type()
+            );
+            assert_eq!(actual_sub.is_primary_key(), expected_sub.is_primary_key());
+            assert_eq!(actual_sub.is_auto_id(), expected_sub.is_auto_id());
+            assert_eq!(
+                actual_sub.is_partition_key(),
+                expected_sub.is_partition_key()
+            );
+            assert_eq!(
+                actual_sub.is_clustering_key(),
+                expected_sub.is_clustering_key()
+            );
+            assert_eq!(actual_sub.is_nullable(), expected_sub.is_nullable());
+            assert_eq!(actual_sub.get_type_params(), expected_sub.get_type_params());
+            assert_eq!(
+                actual_sub.get_index_params(),
+                expected_sub.get_index_params()
+            );
+            assert_eq!(
+                actual_sub.get_default_value(),
+                expected_sub.get_default_value()
+            );
+        }
+    }
     assert_eq!(
-        returned_schema.get_functions().to_owned(),
-        schema.get_functions()
+        returned_schema.get_functions().len(),
+        schema.get_functions().len()
     );
+    for expected in schema.get_functions() {
+        let actual = returned_schema
+            .get_functions()
+            .iter()
+            .find(|function| function.get_name() == expected.get_name())
+            .expect("described function");
+        assert_eq!(actual.get_description(), expected.get_description());
+        assert_eq!(actual.get_function_type(), expected.get_function_type());
+        assert_eq!(actual.get_input_fields(), expected.get_input_fields());
+        assert_eq!(actual.get_output_fields(), expected.get_output_fields());
+        assert_eq!(actual.get_params(), expected.get_params());
+    }
     for (key, value) in &properties {
         assert_eq!(
             returned_schema.get_properties().get(key).to_owned(),

--- a/tests/v2/ut/utility.rs
+++ b/tests/v2/ut/utility.rs
@@ -500,7 +500,7 @@ async fn utility_interfaces_reach_rpc_server() {
     let analyzer = client
         .run_analyzer(
             RunAnalyzerRequest::builder()
-                .analyzer_params("{}")
+                .analyzer_params(serde_json::json!({}))
                 .texts(["hello"])
                 .build()
                 .expect("valid request"),


### PR DESCRIPTION
Change RunAnalyzerRequest.analyzer_params from String to an optional serde_json::Value so callers pass a JSON object (matching the C++ and Java SDKs); into_proto serializes it back to the string wire field. This is an intentional incompatible API change.

Close pymilvus parity gaps reported against the main dev line:

- CreateSimpleCollectionRequest now accepts num_shards, num_partitions, properties, description, and id_type string aliases ("int"/"string"/"str").
- LoadCollectionRequest and LoadPartitionsRequest accept load_priority, forwarded as the load_priority load param.
- DmlResponse exposes cost() parsed from the server status report_value.
- describe_collection exposes consistency_level_name, CollectionSchema schema_version, FieldSchema field_id/is_dynamic/is_function_output, and Function id/input_field_ids/output_field_ids.