### PR TITLE
Align use_database and add_collection_field with pymilvus

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -26,9 +26,9 @@ pull_request_rules:
   - name: Add ci-passed when eligible
     conditions:
       - 'base~=^(main|[0-9]+[.][0-9]+)$'
-      - "check-success=UT on Ubuntu-22.04"
-      - "check-success=UT on MacOS 15"
-      - "check-success=UT on Windows"
+      - "check-success=Build and test on Ubuntu-22.04"
+      - "check-success=Build and test on MacOS 15"
+      - "check-success=Build and test on Windows"
     actions:
       label:
         add:
@@ -39,9 +39,9 @@ pull_request_rules:
       - 'base~=^(main|[0-9]+[.][0-9]+)$'
       - label=ci-passed
       - or:
-        - "-check-success=UT on Ubuntu-22.04"
-        - "-check-success=UT on MacOS 15"
-        - "-check-success=UT on Windows"
+        - "-check-success=Build and test on Ubuntu-22.04"
+        - "-check-success=Build and test on MacOS 15"
+        - "-check-success=Build and test on Windows"
       - files~=^(?!\.github\/mergify\.yml).*$
       - files~=\.(?!md|png)
     actions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Unittest
+name: Build and Test
 
 on:
   push:
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   ut-linux:
-    name: UT on Ubuntu-${{ matrix.ubuntu }}
+    name: Build and test on Ubuntu-${{ matrix.ubuntu }}
     # The type of runner that the job will run on
     runs-on: ubuntu-${{ matrix.ubuntu }}
     timeout-minutes: 60
@@ -93,7 +93,7 @@ jobs:
           flags: ubuntu-${{ matrix.ubuntu }}-unittests
 
   ut-macos:
-    name: UT on MacOS 15
+    name: Build and test on MacOS 15
     if: github.event_name == 'pull_request'
     runs-on: macos-15
     timeout-minutes: 45
@@ -118,7 +118,7 @@ jobs:
         run: ./scripts/run_tests.sh --no-server
 
   ut-windows:
-    name: UT on Windows
+    name: Build and test on Windows
     runs-on: windows-latest
     timeout-minutes: 45
     env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,15 +81,73 @@ reviewing code.
   non-idempotent mutations (insert/upsert/delete/truncate/credential/resource-transfer/snapshot
   mutations) after ambiguous transport failures.
 
-## Build, format, lint, test
+## Build, format, lint
 
-- `cargo test --lib`, `cargo test --test v2_ut` (unit; no server), `cargo test --doc`.
 - `cargo check --all-targets` (also compiles examples and server-backed system tests).
 - `cargo fmt --all -- --check` and `git diff --check` before handoff.
-- Server-backed system tests are under `tests/v2/st`; ask before starting Docker or running
-  destructive tests.
-- V2 examples live under `examples/v2` (V1 under `examples/v1`) and import
-  `milvus::v2::prelude::*`; use uppercase collection names `RUST_V2_<EXAMPLE_NAME>`.
+- Use Clippy when requested or proportionate to the change.
+
+## Examples
+
+- V2 examples live under `examples/v2` (V1 under `examples/v1`).
+- V2 examples import `milvus::v2::prelude::*` and use the V2 request/type APIs.
+- Use uppercase collection names `RUST_V2_<EXAMPLE_NAME>`.
+- Compile without running them when no live Milvus mutation is requested:
+  `cargo build --examples`.
+- Examples connect to Milvus and may create, modify, or delete resources; review connection
+  settings before running and clean up resources they create.
+
+## Tutorials
+
+- Standalone application crates under `tutorial/` (`1_quickstart` through `8_rbac`), one per
+  path in `tutorial/README.md`. Each pins the published `milvus-sdk-rust` version in its
+  `Cargo.toml`; keep tutorial code and the pinned version mutually compatible in the same commit.
+- Tutorial code changes (including README output and version references) land in lockstep with a
+  release-prep PR that bumps the pin, as done for previous releases; do not update tutorial code
+  to an unpublished API surface without also bumping its pinned dependency.
+- Keep tutorial READMEs beginner-oriented: first-run command, default endpoint/credential
+  assumptions, representative output, and concise troubleshooting.
+- `scripts/run_tests.sh` compile-checks tutorials against the current checkout with a temporary
+  Cargo patch; `scripts/run_tutorials.sh` runs them against one standalone Milvus container using
+  the pinned crates.io version.
+
+## Tests
+
+The test suite has three tiers. Run the tier that matches the change; the fast tiers require no
+Milvus server.
+
+### Unit tests (`cargo test --lib`)
+
+- In-crate `#[cfg(test)]` modules co-located with the code (e.g. `src/v2/request/*.rs`,
+  `src/v2/client/*.rs`, `src/v2/types/*.rs`). No server, no network.
+- Cover builder validation, protobuf encoding/decoding, value-type invariants, cache/retry logic,
+  and internal helpers.
+- Run with `cargo test --lib`. Prefer this tier for request/response/type logic that needs no RPC.
+
+### Integration tests (`cargo test --test v2_ut`)
+
+- `tests/v2/ut/` targets the `v2_ut` test binary. It exercises `ClientV2` methods against the
+  local in-process `MockServer` (`tests/v2/ut/common.rs`), which records RPCs, stores server-side
+  state, and can inject transport failures (`fail_next_transport`) or per-RPC error responses.
+- No Milvus server or Docker required. Run with `cargo test --test v2_ut`.
+- Add a mock handler in `tests/v2/ut/common.rs` when a feature dispatches a new RPC, and assert
+  wire behavior (which RPC fired, request contents, fallback paths, retry/no-retry) here rather
+  than in system tests.
+
+### System tests (`cargo test --test v2_st` / `--test v1_st`)
+
+- `tests/v2/st/` (target `v2_st`) and `tests/v1/` (target `v1_st`) run against a real Milvus
+  server. They validate end-to-end behavior the mock cannot: real schema evolution, RBAC
+  enforcement, server-side validation, and cross-component DML/DQL flows.
+- They require Milvus at `http://localhost:19530` (override with `MILVUS_URI`) and may create,
+  modify, and delete resources. Ask before starting Docker or running destructive tests.
+- On Linux, `./scripts/run_tests.sh` starts a managed standalone Milvus container, runs the
+  non-server checks and `v1_st`/`v2_st`, then removes the container.
+- Server-backed tests must clean up resources they create; prefer unique names in concurrent tests.
+
+### Doctests (`cargo test --doc`)
+
+- `cargo test --doc` compiles and runs `///` examples. Keep them current with API changes.
 
 ## Commits and PRs
 

--- a/examples/v2/db.rs
+++ b/examples/v2/db.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
             .get("database.replica.number")
             .map_or("", String::as_str)
     );
-    client.use_database(DATABASE)?;
+    client.use_database(DATABASE).await?;
     println!("Current in-used database: {}", client.current_database());
 
     drop_collection(&client, COLLECTION).await;
@@ -189,7 +189,7 @@ async fn main() -> Result<()> {
         .await?;
     println!("partition count(*) = {}", query_count(count.results())?);
 
-    client.use_database("default")?;
+    client.use_database("default").await?;
     println!("Current in-used database: {}", client.current_database());
     let query = client
         .query(
@@ -227,7 +227,7 @@ async fn main() -> Result<()> {
         .await?;
     print_search_results(search.results())?;
 
-    client.use_database(DATABASE)?;
+    client.use_database(DATABASE).await?;
     println!("Current in-used database: {}", client.current_database());
     client
         .release_collection(
@@ -268,7 +268,7 @@ async fn main() -> Result<()> {
             .map_or("0", String::as_str)
     );
     drop_collection(&client, COLLECTION).await;
-    client.use_database("")?;
+    client.use_database("").await?;
     println!("Current in-used database: {}", client.current_database());
     client
         .drop_database(

--- a/examples/v2/general.rs
+++ b/examples/v2/general.rs
@@ -230,7 +230,7 @@ async fn main() -> Result<()> {
         "\nPartitions of {COLLECTION}: {:?}",
         partitions.partition_names()
     );
-    client.use_database(DATABASE)?;
+    client.use_database(DATABASE).await?;
 
     let mut rng = rand::thread_rng();
     let ids = (0..2000).collect::<Vec<i64>>();
@@ -408,7 +408,7 @@ async fn main() -> Result<()> {
             .map_or("0", String::as_str)
     );
     drop_collection(&client, COLLECTION).await;
-    client.use_database("default")?;
+    client.use_database("default").await?;
     if created_database {
         client
             .drop_database(

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -281,10 +281,12 @@ impl Interceptor for V2Interceptor {
 /// - DDL operations that change a database, collection identity, schema, or alias should be
 ///   serialized with DML and DQL calls targeting the affected objects. Results are not guaranteed
 ///   when those operations overlap.
-/// - [`ClientV2::use_database`], [`ClientV2::set_rpc_deadline`], [`ClientV2::set_retry_param`],
-///   and `update_password` with `reset_connection` (which re-establishes the shared channel and
-///   credentials) are internally synchronized but update state shared by every clone. Serialize
-///   configuration changes with RPC creation when deterministic request settings are required.
+/// - [`ClientV2::use_database`] verifies the target database exists (a `describe_database` RPC)
+///   before switching, then updates state shared by every clone; [`ClientV2::set_rpc_deadline`],
+///   [`ClientV2::set_retry_param`], and `update_password` with `reset_connection` (which
+///   re-establishes the shared channel and credentials) are internally synchronized but update
+///   state shared by every clone. Serialize configuration changes with RPC creation when
+///   deterministic request settings are required.
 #[derive(Clone)]
 pub struct ClientV2 {
     service: SharedServices,

--- a/src/v2/client/collection.rs
+++ b/src/v2/client/collection.rs
@@ -487,21 +487,51 @@ impl ClientV2 {
     }
 
     /// Add a field to an existing collection.
+    ///
+    /// The field is added through the modern `AlterCollectionSchema` RPC (as in pymilvus/java/cpp),
+    /// falling back to the legacy `AddCollectionField` RPC when the server does not support schema
+    /// alteration (gRPC `UNIMPLEMENTED` or an external-collection alter rejection).
     pub async fn add_collection_field(
         &self,
         request: request::collection::AddCollectionFieldRequest,
     ) -> Result<()> {
         let database = self.effective_database(request.database_name.as_deref());
         let collection = request.collection_name.clone();
+        let alter = request.clone().into_alter_schema_proto()?;
+        let response = self
+            .retry_rpc(
+                || Ok(alter.clone()),
+                super::RetrySemantics::Idempotent,
+                |mut service, request| async move { service.alter_collection_schema(request).await },
+                |response| response.alter_status.clone(),
+            )
+            .await;
+        match response {
+            Ok(_) => {}
+            Err(Error::Grpc(status)) if status.code() == tonic::Code::Unimplemented => {
+                self.add_collection_field_legacy(request).await?;
+            }
+            Err(Error::Server(error)) if external_collection_alter_unsupported(&error) => {
+                self.add_collection_field_legacy(request).await?;
+            }
+            Err(error) => return Err(error),
+        }
+        self.remove_collection_description(&database, &collection);
+        Ok(())
+    }
+
+    /// Adds a field through the legacy `AddCollectionField` RPC.
+    async fn add_collection_field_legacy(
+        &self,
+        request: request::collection::AddCollectionFieldRequest,
+    ) -> Result<()> {
         let status = status_rpc_with_retry!(
             Idempotent,
             self,
             add_collection_field,
             request.into_proto()?
         )?;
-        self.status(status)?;
-        self.remove_collection_description(&database, &collection);
-        Ok(())
+        self.status(status)
     }
 
     /// Add a function to an existing collection.
@@ -649,4 +679,15 @@ impl ClientV2 {
         self.remove_collection_description(&database, &collection);
         Ok(())
     }
+}
+
+/// Whether an `AlterCollectionSchema` rejection signals that schema alteration is unsupported for
+/// an external collection, in which case the legacy `AddCollectionField` RPC should be used
+/// (mirroring pymilvus's `is_external_collection_schema_alter_unsupported`).
+fn external_collection_alter_unsupported(error: &crate::v2::error::ServerError) -> bool {
+    let invalid_parameter = error.code() == 1100 || error.legacy_code() == 5;
+    invalid_parameter
+        && error
+            .reason()
+            .contains("alter collection schema operation is not supported for external collection")
 }

--- a/src/v2/client/database.rs
+++ b/src/v2/client/database.rs
@@ -24,28 +24,42 @@ use crate::v2::{request, response};
 impl ClientV2 {
     /// Selects the database used by subsequent operations on this client and its clones.
     ///
-    /// This changes client-side routing metadata; it does not create the database or verify that
-    /// it exists. Use [`ClientV2::describe_database`] or a database operation to validate it.
-    pub fn use_database(&self, database: impl Into<String>) -> Result<()> {
+    /// When switching to an explicitly named database, the target is first verified to exist via
+    /// [`ClientV2::describe_database`] (matching pymilvus) and the switch fails with the server
+    /// error when it does not. Passing an empty name resets the selection to the always-present
+    /// `default` database without an extra RPC.
+    pub async fn use_database(&self, database: impl Into<String>) -> Result<()> {
         let database = database.into();
         let explicit = !database.is_empty();
         let database = normalize_database(database)?;
 
         if explicit {
-            // Publish the selected name before declaring it explicit. A concurrent
-            // reader can therefore observe only the old selection or the new one.
+            let request = request::database::DescribeDatabaseRequest::builder()
+                .database_name(database.clone())
+                .build()?;
+            self.describe_database(request).await?;
+        }
+
+        self.select_database(database, explicit);
+        Ok(())
+    }
+
+    /// Publishes the database selection to the shared routing state.
+    ///
+    /// For an explicit selection the name is published before the explicitness flag so a
+    /// concurrent reader observes either the old selection or the new one. For a reset the
+    /// explicitness flag is cleared before the normalized default is published so a concurrent
+    /// reader never observes an omitted database reported as an explicit `default`.
+    fn select_database(&self, database: String, explicit: bool) {
+        if explicit {
             *self.database.write() = database;
             self.database_explicit
                 .store(true, std::sync::atomic::Ordering::Release);
         } else {
-            // Clear explicitness before publishing the normalized default. Reversing
-            // this order could transiently report an omitted database as explicit
-            // `default` while switching from a previously explicit selection.
             self.database_explicit
                 .store(false, std::sync::atomic::Ordering::Release);
             *self.database.write() = database;
         }
-        Ok(())
     }
 
     /// Returns the database currently selected by this client.
@@ -183,7 +197,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn use_database_updates_shared_selection_without_clearing_global_schema_cache() {
+    async fn select_database_updates_shared_selection_without_clearing_global_schema_cache() {
         let client = client();
         let clone = client.clone();
         SCHEMA_CACHE.set(
@@ -193,7 +207,7 @@ mod tests {
             milvus::DescribeCollectionResponse::default(),
         );
 
-        client.use_database("catalog").expect("switch database");
+        client.select_database("catalog".to_owned(), true);
 
         assert_eq!(client.current_database(), "catalog");
         assert_eq!(clone.current_database(), "catalog");
@@ -204,38 +218,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn use_database_normalizes_default_and_rejects_invalid_metadata() {
+    async fn use_database_rejects_invalid_metadata_before_switching() {
         let client = client();
-
-        *client.database.write() = String::new();
-        assert_eq!(client.current_database(), "default");
-
-        client
-            .use_database("default")
-            .expect("select explicit default database");
-        assert!(client
-            .database_explicit
-            .load(std::sync::atomic::Ordering::Acquire));
-
-        client.use_database("").expect("select default database");
-        assert_eq!(client.current_database(), "default");
-        assert!(!client
-            .database_explicit
-            .load(std::sync::atomic::Ordering::Acquire));
 
         let error = client
             .use_database("invalid\nname")
+            .await
             .expect_err("reject invalid database metadata");
         assert!(matches!(error, Error::Validation(_)));
         assert_eq!(client.current_database(), "default");
     }
 
     #[tokio::test]
-    async fn use_database_reset_clears_explicitness_before_publishing_default() {
+    async fn select_database_normalizes_default_explicitness() {
         let client = client();
-        client
-            .use_database("catalog")
-            .expect("select explicit database");
+
+        *client.database.write() = String::new();
+        assert_eq!(client.current_database(), "default");
+
+        client.select_database("default".to_owned(), true);
+        assert!(client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire));
+
+        client.select_database("default".to_owned(), false);
+        assert_eq!(client.current_database(), "default");
+        assert!(!client
+            .database_explicit
+            .load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn select_database_reset_clears_explicitness_before_publishing_default() {
+        let client = client();
+        client.select_database("catalog".to_owned(), true);
 
         // Hold a reader so the reset thread blocks immediately before publishing
         // the normalized default. It must still be able to clear explicitness first.
@@ -244,7 +260,7 @@ mod tests {
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let reset = std::thread::spawn(move || {
             started_tx.send(()).expect("signal reset start");
-            reset_client.use_database("").expect("reset database");
+            reset_client.select_database("default".to_owned(), false);
         });
         started_rx.recv().expect("reset thread started");
 

--- a/src/v2/request/collection.rs
+++ b/src/v2/request/collection.rs
@@ -2170,6 +2170,35 @@ impl AddCollectionFieldRequest {
             ..Default::default()
         })
     }
+
+    /// Encodes the request as an `AlterCollectionSchemaRequest` add-field action, the modern
+    /// RPC that pymilvus/java/cpp use for `add_collection_field` (falling back to
+    /// `AddCollectionField` only when the server reports UNIMPLEMENTED).
+    pub(crate) fn into_alter_schema_proto(self) -> Result<milvus::AlterCollectionSchemaRequest> {
+        use crate::proto::milvus::alter_collection_schema_request::{self as req};
+
+        let field = self
+            .field
+            .ok_or_else(|| Error::validation("field".into(), "must be specified".into()))?;
+        let add_request = req::AddRequest {
+            field_infos: vec![req::FieldInfo {
+                field_schema: Some(field.into_proto()),
+                index_name: String::new(),
+                extra_params: Vec::new(),
+            }],
+            func_schema: Vec::new(),
+            do_physical_backfill: false,
+        };
+        Ok(milvus::AlterCollectionSchemaRequest {
+            base: None,
+            db_name: self.database_name.unwrap_or_default(),
+            collection_name: self.collection_name,
+            collection_id: 0,
+            action: Some(req::Action {
+                op: Some(req::action::Op::AddRequest(add_request)),
+            }),
+        })
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2216,6 +2245,12 @@ impl AddCollectionFieldRequestBuilder {
             return Err(Error::validation(
                 "field.data_type".into(),
                 "must be specified".into(),
+            ));
+        }
+        if field.get_data_type().is_vector() && !field.is_nullable() {
+            return Err(Error::validation(
+                "field.nullable".into(),
+                "adding a vector field to an existing collection requires nullable = true".into(),
             ));
         }
         field.validate()?;
@@ -4668,6 +4703,84 @@ mod builder_value_tests {
         assert_eq!(value.database_name().to_owned(), Some(database_name));
         assert_eq!(value.collection_name().to_owned(), collection_name);
         assert_eq!(value.field(), Some(&field));
+    }
+
+    #[test]
+    fn add_collection_field_encodes_alter_schema_add_request() {
+        let field = FieldSchema::new()
+            .name("embedding")
+            .data_type(DataType::FloatVector)
+            .dimension(4)
+            .nullable(true);
+        let proto = AddCollectionFieldRequest::builder()
+            .database_name("catalog")
+            .collection_name("books")
+            .field(field)
+            .build()
+            .expect("valid request")
+            .into_alter_schema_proto()
+            .expect("valid proto");
+        assert_eq!(proto.db_name, "catalog");
+        assert_eq!(proto.collection_name, "books");
+        let add = match proto.action.and_then(|action| action.op) {
+            Some(milvus::alter_collection_schema_request::action::Op::AddRequest(add)) => add,
+            _ => panic!("expected AddRequest action"),
+        };
+        assert_eq!(add.field_infos.len(), 1);
+        let info = &add.field_infos[0];
+        let schema = info.field_schema.as_ref().expect("field schema present");
+        assert_eq!(schema.name, "embedding");
+        assert!(schema.nullable);
+    }
+
+    #[test]
+    fn add_collection_field_rejects_non_nullable_vector_field() {
+        let error = AddCollectionFieldRequest::builder()
+            .collection_name("books")
+            .field(
+                FieldSchema::new()
+                    .name("embedding")
+                    .data_type(DataType::FloatVector)
+                    .dimension(4),
+            )
+            .build()
+            .expect_err("non-nullable vector field must be rejected");
+        assert!(matches!(error, Error::Validation(_)));
+    }
+
+    #[test]
+    fn add_collection_field_accepts_nullable_vector_field() {
+        let value = AddCollectionFieldRequest::builder()
+            .collection_name("books")
+            .field(
+                FieldSchema::new()
+                    .name("embedding")
+                    .data_type(DataType::FloatVector)
+                    .dimension(4)
+                    .nullable(true),
+            )
+            .build()
+            .expect("nullable vector field is accepted");
+        let field = value.field().expect("field is present");
+        assert_eq!(field.get_name(), "embedding");
+        assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn add_collection_field_accepts_non_nullable_scalar_field() {
+        let value = AddCollectionFieldRequest::builder()
+            .collection_name("books")
+            .field(
+                FieldSchema::new()
+                    .name("note")
+                    .data_type(DataType::VarChar)
+                    .max_length(128),
+            )
+            .build()
+            .expect("non-nullable scalar field is passed through to the server");
+        let field = value.field().expect("field is present");
+        assert_eq!(field.get_name(), "note");
+        assert!(!field.is_nullable());
     }
 
     #[test]

--- a/tests/v2/st/database.rs
+++ b/tests/v2/st/database.rs
@@ -108,6 +108,7 @@ async fn database_lifecycle_and_selection() {
 
     client
         .use_database(&database)
+        .await
         .expect("use created database");
     assert_eq!(client.current_database(), database);
     common::create_advanced_collection(&client, &collection).await;
@@ -117,6 +118,7 @@ async fn database_lifecycle_and_selection() {
 
     client
         .use_database("default")
+        .await
         .expect("use default database");
     client
         .drop_database(

--- a/tests/v2/ut/collection.rs
+++ b/tests/v2/ut/collection.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 use super::common::MockServer;
+use milvus::proto::common;
 use milvus::v2::error::Error;
 use milvus::v2::request::collection::*;
 use milvus::v2::request::dml::InsertRequest;
@@ -695,7 +696,10 @@ async fn collection_interfaces_reach_rpc_server() {
         "rename_collection",
         &["old_name: \"books\"", "new_name: \"renamed_books\""],
     );
-    server.assert_request_contains("add_collection_field", &["schema:"]);
+    server.assert_request_contains(
+        "alter_collection_schema",
+        &["collection_name: \"books\"", "AddRequest("],
+    );
     server.assert_request_contains("add_collection_function", &["name: \"bm25\""]);
     server.assert_request_contains("alter_collection_function", &["function_name: \"bm25\""]);
     server.assert_request_contains("drop_collection_function", &["function_name: \"bm25\""]);
@@ -734,7 +738,7 @@ async fn collection_interfaces_reach_rpc_server() {
         "rename_collection",
         "alter_collection",
         "alter_collection_field",
-        "add_collection_field",
+        "alter_collection_schema",
         "add_collection_function",
         "alter_collection_function",
         "drop_collection_function",
@@ -742,6 +746,109 @@ async fn collection_interfaces_reach_rpc_server() {
     ] {
         server.assert_called(rpc);
     }
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn add_collection_field_falls_back_to_legacy_rpc_when_schema_alter_unsupported() {
+    let server = MockServer::start().await;
+    server
+        .service
+        .set_alter_collection_schema_unimplemented(true);
+
+    server
+        .client
+        .add_collection_field(
+            AddCollectionFieldRequest::builder()
+                .collection_name("books")
+                .field(
+                    FieldSchema::new()
+                        .name("extra")
+                        .data_type(DataType::Int64)
+                        .nullable(true),
+                )
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .expect("add collection field via legacy fallback");
+    server.assert_called("alter_collection_schema");
+    server.assert_request_contains("add_collection_field", &["schema:"]);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+#[allow(deprecated)]
+async fn add_collection_field_falls_back_to_legacy_rpc_for_external_collection() {
+    let server = MockServer::start().await;
+    server
+        .service
+        .set_alter_collection_schema_status(common::Status {
+            code: 1100,
+            error_code: common::ErrorCode::UnexpectedError as i32,
+            reason:
+                "alter collection schema operation is not supported for external collection books"
+                    .into(),
+            ..Default::default()
+        });
+
+    server
+        .client
+        .add_collection_field(
+            AddCollectionFieldRequest::builder()
+                .collection_name("books")
+                .field(
+                    FieldSchema::new()
+                        .name("extra")
+                        .data_type(DataType::Int64)
+                        .nullable(true),
+                )
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .expect("add collection field via external-collection fallback");
+    server.assert_called("alter_collection_schema");
+    server.assert_request_contains("add_collection_field", &["schema:"]);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+#[allow(deprecated)]
+async fn add_collection_field_propagates_unrelated_schema_alter_errors() {
+    let server = MockServer::start().await;
+    server
+        .service
+        .set_alter_collection_schema_status(common::Status {
+            code: 1002,
+            error_code: common::ErrorCode::UnexpectedError as i32,
+            reason: "unrelated alter failure".into(),
+            ..Default::default()
+        });
+
+    let error = server
+        .client
+        .add_collection_field(
+            AddCollectionFieldRequest::builder()
+                .collection_name("books")
+                .field(
+                    FieldSchema::new()
+                        .name("extra")
+                        .data_type(DataType::Int64)
+                        .nullable(true),
+                )
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .expect_err("unrelated alter failure must propagate");
+    assert!(matches!(error, milvus::v2::error::Error::Server(_)));
+    server.assert_called("alter_collection_schema");
+    assert_eq!(
+        server.service.call_count("add_collection_field"),
+        0,
+        "legacy add_collection_field must not be invoked for unrelated errors"
+    );
     server.shutdown().await;
 }
 

--- a/tests/v2/ut/common.rs
+++ b/tests/v2/ut/common.rs
@@ -46,6 +46,8 @@ struct MockState {
     client_request_ids: HashMap<&'static str, Vec<Option<String>>>,
     authorization_headers: HashMap<&'static str, Vec<Option<String>>>,
     transport_failures: HashMap<&'static str, Vec<tonic::Code>>,
+    alter_collection_schema_unimplemented: bool,
+    alter_collection_schema_status: Option<common::Status>,
     aliases: HashMap<(String, String), String>,
     databases: HashMap<String, HashMap<String, String>>,
     replicate_configuration: Option<common::ReplicateConfiguration>,
@@ -70,6 +72,8 @@ impl Default for MockState {
             client_request_ids: HashMap::new(),
             authorization_headers: HashMap::new(),
             transport_failures: HashMap::new(),
+            alter_collection_schema_unimplemented: false,
+            alter_collection_schema_status: None,
             aliases: HashMap::new(),
             databases: HashMap::new(),
             replicate_configuration: None,
@@ -201,6 +205,17 @@ impl MockMilvus {
             .entry(method)
             .or_default()
             .push(code);
+    }
+
+    pub fn set_alter_collection_schema_unimplemented(&self, value: bool) {
+        self.state
+            .lock()
+            .unwrap()
+            .alter_collection_schema_unimplemented = value;
+    }
+
+    pub fn set_alter_collection_schema_status(&self, status: common::Status) {
+        self.state.lock().unwrap().alter_collection_schema_status = Some(status);
     }
 
     fn take_transport_failure(&self, method: &'static str) -> Option<Status> {
@@ -686,6 +701,30 @@ impl MilvusService for MockMilvus {
     );
     status_method!(alter_collection_field, pb::AlterCollectionFieldRequest);
     status_method!(add_collection_field, pb::AddCollectionFieldRequest);
+    response_method_with!(
+        alter_collection_schema,
+        pb::AlterCollectionSchemaRequest,
+        pb::AlterCollectionSchemaResponse,
+        |service, request| {
+            let mut state = service.state.lock().unwrap();
+            if state.alter_collection_schema_unimplemented {
+                // Simulate an older server that does not support schema alteration so the
+                // client falls back to the legacy AddCollectionField RPC.
+                return Err(tonic::Status::unimplemented(
+                    "schema alteration unsupported",
+                ));
+            }
+            pb::AlterCollectionSchemaResponse {
+                alter_status: Some(
+                    state
+                        .alter_collection_schema_status
+                        .take()
+                        .unwrap_or_else(success_status),
+                ),
+                ..Default::default()
+            }
+        }
+    );
     status_method!(add_collection_function, pb::AddCollectionFunctionRequest);
     status_method!(
         alter_collection_function,
@@ -2421,27 +2460,39 @@ impl MilvusService for MockMilvus {
         pb::DescribeDatabaseRequest,
         pb::DescribeDatabaseResponse,
         |service, request| {
-            let properties = service
-                .state
-                .lock()
-                .unwrap()
-                .databases
-                .get(&request.db_name)
-                .cloned()
-                .unwrap_or_default();
-            pb::DescribeDatabaseResponse {
-                status: Some(success_status()),
-                db_name: request.db_name,
-                db_id: 20,
-                created_timestamp: 200,
-                properties: properties
-                    .into_iter()
-                    .map(|(key, value)| common::KeyValuePair {
-                        key,
-                        value,
+            let state = service.state.lock().unwrap();
+            let known =
+                request.db_name == "default" || state.databases.contains_key(&request.db_name);
+            if !known {
+                pb::DescribeDatabaseResponse {
+                    status: Some(common::Status {
+                        code: 800,
+                        error_code: common::ErrorCode::UnexpectedError as i32,
+                        reason: format!("database {} not found", request.db_name),
                         ..Default::default()
-                    })
-                    .collect(),
+                    }),
+                    ..Default::default()
+                }
+            } else {
+                let properties = state
+                    .databases
+                    .get(&request.db_name)
+                    .cloned()
+                    .unwrap_or_default();
+                pb::DescribeDatabaseResponse {
+                    status: Some(success_status()),
+                    db_name: request.db_name,
+                    db_id: 20,
+                    created_timestamp: 200,
+                    properties: properties
+                        .into_iter()
+                        .map(|(key, value)| common::KeyValuePair {
+                            key,
+                            value,
+                            ..Default::default()
+                        })
+                        .collect(),
+                }
             }
         }
     );

--- a/tests/v2/ut/database.rs
+++ b/tests/v2/ut/database.rs
@@ -22,8 +22,6 @@ async fn database_interfaces_reach_rpc_server() {
     let server = MockServer::start().await;
     let client = &server.client;
 
-    client.use_database("tenant").unwrap();
-    assert_eq!(client.current_database(), "tenant");
     client
         .create_database(
             CreateDatabaseRequest::builder()
@@ -37,6 +35,8 @@ async fn database_interfaces_reach_rpc_server() {
         )
         .await
         .unwrap();
+    client.use_database("tenant").await.unwrap();
+    assert_eq!(client.current_database(), "tenant");
     let databases = client
         .list_databases(
             ListDatabasesRequest::builder()
@@ -144,6 +144,57 @@ async fn database_interfaces_reach_rpc_server() {
         "drop_database",
     ] {
         server.assert_called(rpc);
+    }
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn use_database_rejects_missing_database_without_switching() {
+    let server = MockServer::start().await;
+    let client = &server.client;
+
+    let error = client
+        .use_database("missing")
+        .await
+        .expect_err("selecting a missing database must fail");
+    assert!(matches!(error, milvus::v2::error::Error::Server(_)));
+    assert_eq!(client.current_database(), "default");
+    server.assert_called("describe_database");
+
+    client
+        .create_database(
+            CreateDatabaseRequest::builder()
+                .database_name("tenant")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .unwrap();
+    client
+        .use_database("tenant")
+        .await
+        .expect("select existing database");
+    assert_eq!(client.current_database(), "tenant");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn use_database_reset_to_default_does_not_issue_describe_database() {
+    let server = MockServer::start().await;
+    let client = &server.client;
+
+    client
+        .use_database("")
+        .await
+        .expect("reset to default without an RPC");
+    assert_eq!(client.current_database(), "default");
+
+    for rpc in ["describe_database", "list_databases"] {
+        assert_eq!(
+            server.service.call_count(rpc),
+            0,
+            "reset to default must not issue {rpc}"
+        );
     }
     server.shutdown().await;
 }

--- a/tests/v2/ut/dml.rs
+++ b/tests/v2/ut/dml.rs
@@ -214,12 +214,19 @@ async fn local_validation_errors_force_refresh_the_shared_schema() {
 #[tokio::test]
 async fn stale_schema_is_force_refreshed_after_local_validation_mismatch() {
     let server = MockServer::start().await;
+    let describe_before = server.service.call_count("describe_collection");
     server
         .client
         .insert(insert_request())
         .await
         .expect("prime the schema cache");
-    assert_eq!(server.service.call_count("describe_collection"), 1);
+    // The process-wide schema cache may already hold this collection from a concurrent test,
+    // so the first insert issues either zero (cache hit) or one (cache miss) describe.
+    let describe_after_prime = server.service.call_count("describe_collection");
+    assert!(
+        describe_after_prime - describe_before <= 1,
+        "priming the schema cache issues at most one describe_collection"
+    );
 
     server
         .service
@@ -249,7 +256,11 @@ async fn stale_schema_is_force_refreshed_after_local_validation_mismatch() {
         .await
         .expect("insert succeeds after forced schema refresh");
 
-    assert_eq!(server.service.call_count("describe_collection"), 2);
+    assert_eq!(
+        server.service.call_count("describe_collection"),
+        describe_after_prime + 1,
+        "the local validation mismatch must force exactly one schema refresh"
+    );
     assert_eq!(server.service.call_count("insert"), 2);
     server.shutdown().await;
 }

--- a/tests/v2/ut/dql.rs
+++ b/tests/v2/ut/dql.rs
@@ -517,7 +517,17 @@ async fn empty_database_name_uses_selected_database_for_dml_and_session_reads() 
     let client = &server.client;
     let collection = "selected_database_session_books";
     client
+        .create_database(
+            CreateDatabaseRequest::builder()
+                .database_name("tenant")
+                .build()
+                .expect("valid database request"),
+        )
+        .await
+        .expect("create tenant database");
+    client
         .use_database("tenant")
+        .await
         .expect("select tenant database");
     client
         .create_collection(

--- a/tests/v2/ut/iterator.rs
+++ b/tests/v2/ut/iterator.rs
@@ -327,7 +327,17 @@ async fn iterators_treat_empty_database_name_as_the_selected_database() {
     let client = &server.client;
     let collection = "selected_database_iterator_books";
     client
+        .create_database(
+            CreateDatabaseRequest::builder()
+                .database_name("tenant")
+                .build()
+                .expect("valid database request"),
+        )
+        .await
+        .expect("create tenant database");
+    client
         .use_database("tenant")
+        .await
         .expect("select tenant database");
     client
         .create_collection(

--- a/tests/v2/ut/snapshot.rs
+++ b/tests/v2/ut/snapshot.rs
@@ -16,6 +16,7 @@
 
 use super::common::MockServer;
 use milvus::v2::error::Error;
+use milvus::v2::request::database::CreateDatabaseRequest;
 use milvus::v2::request::snapshot::*;
 use milvus::v2::RestoreSnapshotStateCode;
 use tonic::Code;
@@ -191,7 +192,17 @@ async fn snapshot_interfaces_reach_rpc_server() {
 #[tokio::test]
 async fn snapshot_requests_use_the_selected_database() {
     let server = MockServer::start().await;
-    server.client.use_database("analytics").unwrap();
+    server
+        .client
+        .create_database(
+            CreateDatabaseRequest::builder()
+                .database_name("analytics")
+                .build()
+                .expect("valid database request"),
+        )
+        .await
+        .unwrap();
+    server.client.use_database("analytics").await.unwrap();
 
     server
         .client

--- a/tests/v2/ut/utility.rs
+++ b/tests/v2/ut/utility.rs
@@ -19,6 +19,7 @@ use milvus::v2::error::Error;
 use milvus::v2::request::collection::{
     CreateSimpleCollectionRequest, LoadCollectionRequest, RefreshLoadRequest,
 };
+use milvus::v2::request::database::CreateDatabaseRequest;
 use milvus::v2::request::dml::InsertRequest;
 use milvus::v2::request::partition::LoadPartitionsRequest;
 use milvus::v2::request::utility::*;
@@ -88,7 +89,19 @@ async fn compact_and_optimize_direct_describe_bypass_the_schema_cache() {
 async fn empty_database_name_uses_selected_database_for_workflow_rpcs() {
     let server = MockServer::start().await;
     let client = &server.client;
-    client.use_database("tenant").expect("select database");
+    client
+        .create_database(
+            CreateDatabaseRequest::builder()
+                .database_name("tenant")
+                .build()
+                .expect("valid database request"),
+        )
+        .await
+        .expect("create tenant database");
+    client
+        .use_database("tenant")
+        .await
+        .expect("select database");
 
     client
         .create_collection(

--- a/tutorial/7_database/src/main.rs
+++ b/tutorial/7_database/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
         // use_database changes the database selected by this client. Returning to `default` ensures
         // the database being deleted is not still selected.
         println!("Calling use_database: select default");
-        client.use_database("default")?;
+        client.use_database("default").await?;
         println!("use_database completed");
         println!("\nDropping tutorial database {database:?}");
         // drop_database permanently removes the named database; it must contain no collections.
@@ -159,7 +159,7 @@ async fn demonstrate_database_interfaces(client: &ClientV2, database: &str) -> R
 
     // use_database selects this database for requests that omit an explicit database name.
     println!("Calling use_database: select {database:?}");
-    client.use_database(database)?;
+    client.use_database(database).await?;
     println!("use_database completed");
     println!("\nSelected database: {}", client.current_database());
     println!("Subsequent requests with no database_name will use this selected database.");


### PR DESCRIPTION
## Why this change

Fills two pymilvus parity gaps on `ClientV2` found in the rust-vs-pymilvus `main` gap report:

1. **`use_database` did not verify the target database exists.** pymilvus runs `describe_database` before switching; the Rust SDK only updated client-side routing metadata, so a typo'd database was silently selected and failures surfaced far downstream.
2. **`add_collection_field` used only the legacy RPC and accepted non-nullable vector fields.** pymilvus/java/cpp add a field through the modern `AlterCollectionSchema` RPC (falling back to `AddCollectionField` only when the server reports UNIMPLEMENTED), and pymilvus rejects adding a vector field unless `nullable=True`.

## What changed

- **`use_database` is now `async` and verifies existence first** (`src/v2/client/database.rs`):
  - Switching to an explicitly named database issues a `describe_database` RPC before publishing the new selection; on server error the switch fails and the previous selection is kept.
  - Empty-name reset to `default` is unchanged and performs no extra RPC.
  - The shared routing-state update moved into a private `select_database` helper, preserving the existing publish-ordering guarantees for explicit selections and resets.
- **`add_collection_field` now prefers `AlterCollectionSchema`** (`src/v2/client/collection.rs`, `src/v2/request/collection.rs`): like pymilvus/java/cpp, the field is added through the modern `AlterCollectionSchema` RPC, falling back to the legacy `AddCollectionField` RPC on gRPC `UNIMPLEMENTED` or an external-collection alter rejection. This lets non-nullable scalar fields with a `default_value` reach the server (the schema-alter validation path accepts them), matching pymilvus.
- **`AddCollectionFieldRequestBuilder::build` rejects non-nullable vector fields** (`src/v2/request/collection.rs`): a vector `FieldSchema` now requires `nullable = true`, matching pymilvus. Scalar fields pass through to the server.
- Mock server gains an `alter_collection_schema` handler (success by default, UNIMPLEMENTED toggle for the fallback path) and `describe_database` now returns error 800 for unknown databases so the rejection path is exercised in tests.
- Updated all callers of `use_database` (examples, `7_database` tutorial, ut/st tests) to `.await`.

## Breaking change

- `ClientV2::use_database` changed from sync to `async fn`. Users must add `.await` and should note that selecting a non-existent database now fails immediately instead of silently switching routing.
- `add_collection_field` now authorizes with `PrivilegeAlterCollectionSchema` (via `AlterCollectionSchema`) instead of `PrivilegeAddCollectionField`. On RBAC-enabled deployments, custom roles must be granted `PrivilegeAlterCollectionSchema` on the collection (the legacy `AddCollectionField` RPC is only used on UNIMPLEMENTED or external-collection rejection).

## Testing

- `cargo test --lib` (883 passed), `cargo test --test v2_ut` (114 passed), including new `use_database_rejects_missing_database_without_switching`, `use_database_reset_to_default_does_not_issue_describe_database`, `add_collection_field_falls_back_to_legacy_rpc_when_schema_alter_unsupported`, `add_collection_field_falls_back_to_legacy_rpc_for_external_collection`, and `add_collection_field_propagates_unrelated_schema_alter_errors`
- New unit tests for nullable-vector add-field validation and `AlterCollectionSchema` add-request encoding
- `cargo test --doc`, `cargo fmt --all -- --check`, `git diff --check`, clippy clean
- Collection system tests and `v2_nullable_vector` / `v2_add_field` examples verified against a live Milvus 3.0 server
